### PR TITLE
Lost exceptions from master activities

### DIFF
--- a/thorlcr/graph/thgraphmaster.cpp
+++ b/thorlcr/graph/thgraphmaster.cpp
@@ -1771,7 +1771,7 @@ bool CMasterGraph::fireException(IException *e)
             LOG(MCerror, thorJob, e);
             if (NULL != fatalHandler)
                 fatalHandler->inform(LINK(e));
-            else if (owner)
+            if (owner)
                 owner->fireException(e);
             else
                 job.fireException(e);


### PR DESCRIPTION
Most exceptions fired by thor master activities were being logged but not
reported. They were reported to the fatal handler, and after the configured
timeout (60s default) would cause thor to recycle

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
