### PR TITLE
HPCC-9244 - Improved LOOKUP,MANY scheme

### DIFF
--- a/system/jlib/jthread.hpp
+++ b/system/jlib/jthread.hpp
@@ -138,6 +138,8 @@ public:
 interface IThreaded
 {
     virtual void main() = 0;
+protected:
+    virtual ~IThreaded() {}
 };
 
 // utility class, useful for containing a thread

--- a/thorlcr/activities/lookupjoin/thlookupjoin.cpp
+++ b/thorlcr/activities/lookupjoin/thlookupjoin.cpp
@@ -24,6 +24,17 @@ class CLookupJoinActivityMaster : public CMasterActivity
 {
     mptag_t broadcast2MpTag, lhsDistributeTag, rhsDistributeTag;
 
+    bool isAll() const
+    {
+        switch (container.getKind())
+        {
+            case TAKalljoin:
+            case TAKalldenormalize:
+            case TAKalldenormalizegroup:
+                return true;
+        }
+        return false;
+    }
 public:
     CLookupJoinActivityMaster(CMasterGraphElement * info) : CMasterActivity(info)
     {
@@ -32,14 +43,17 @@ public:
         else
         {
             mpTag = container.queryJob().allocateMPTag(); // NB: base takes ownership and free's
-            broadcast2MpTag = container.queryJob().allocateMPTag();
-            lhsDistributeTag = container.queryJob().allocateMPTag();
-            rhsDistributeTag = container.queryJob().allocateMPTag();
+            if (!isAll())
+            {
+                broadcast2MpTag = container.queryJob().allocateMPTag();
+                lhsDistributeTag = container.queryJob().allocateMPTag();
+                rhsDistributeTag = container.queryJob().allocateMPTag();
+            }
         }
     }
     ~CLookupJoinActivityMaster()
     {
-        if (!container.queryLocal())
+        if (!container.queryLocal() && !isAll())
         {
             container.queryJob().freeMPTag(broadcast2MpTag);
             container.queryJob().freeMPTag(lhsDistributeTag);
@@ -52,14 +66,17 @@ public:
         if (!container.queryLocal())
         {
             serializeMPtag(dst, mpTag);
-            serializeMPtag(dst, broadcast2MpTag);
-            serializeMPtag(dst, lhsDistributeTag);
-            serializeMPtag(dst, rhsDistributeTag);
+            if (!isAll())
+            {
+                serializeMPtag(dst, broadcast2MpTag);
+                serializeMPtag(dst, lhsDistributeTag);
+                serializeMPtag(dst, rhsDistributeTag);
+            }
         }
     }
     void process()
     {
-        if (!container.queryLocal() && container.queryJob().querySlaves() > 1)
+        if (!container.queryLocal() && isAll() && container.queryJob().querySlaves() > 1)
         {
             CMessageBuffer msg;
             unsigned nslaves = container.queryJob().querySlaves();

--- a/thorlcr/activities/lookupjoin/thlookupjoinslave.cpp
+++ b/thorlcr/activities/lookupjoin/thlookupjoinslave.cpp
@@ -436,172 +436,221 @@ public:
     }
 };
 
+/* CMarker processes a sorted set of rows, comparing every adjacent row.
+ * It creates a bitmap, where 1 represents row N mismatches N+1
+ * Multiple threads are used to process blocks of the table in parallel
+ * When complete, it knows how unique values there are in the table
+ * which can be stepped through with findNextBoundary()
+ */
+class CMarker
+{
+    CActivityBase &activity;
+    NonReentrantSpinLock lock;
+    ICompare *cmp;
+    Owned<IBitSet> bitSet; // should be roxiemem, so can cause spilling
+    const void **base;
+    rowidx_t startRow, endRow, chunkSize, next;
+    unsigned unique;
+    unsigned minForParallel, parallelMinChunkSize, parallelChunkSize;
+
+    class CCompareThread : public CInterface, implements IThreaded
+    {
+        CMarker &parent;
+        CThreaded threaded;
+        rowidx_t startRow, endRow;
+    public:
+        CCompareThread(CMarker &_parent, rowidx_t _startRow, rowidx_t _endRow)
+            : parent(_parent), startRow(_startRow), endRow(_endRow), threaded("CCompareThread", this)
+        {
+        }
+        void start() { threaded.start(); }
+        void join() { threaded.join(); }
+    // IThreaded
+        virtual void main()
+        {
+            parent.run(startRow, endRow);
+        }
+    };
+    CIArrayOf<CCompareThread> threads;
+
+    rowidx_t getMore(rowidx_t &_startRow)
+    {
+        NonReentrantSpinBlock block(lock);
+        if (startRow == endRow)
+            return 0;
+        _startRow = startRow;
+        if (endRow-startRow <= chunkSize)
+            startRow = endRow;
+        else
+            startRow += chunkSize;
+        return startRow;
+    }
+    inline void mark(rowidx_t i)
+    {
+        ++unique;
+        bitSet->set(i); // mark boundary
+    }
+    void run(rowidx_t myStart, rowidx_t myEnd)
+    {
+        loop
+        {
+            const void **rows = base+myStart;
+            rowidx_t i=myStart;
+            for (; i<(myEnd-1); i++, rows++)
+            {
+                int r = cmp->docompare(*rows, *(rows+1));
+                if (r)
+                    mark(i);
+                /* JCSMORE - could I binchop ahead somehow, to process duplicates more quickly..
+                 * i.e. if same cur+mid = cur, then no need to check intermediates..
+                 */
+            }
+            if (myEnd != endRow)
+            {
+                // final row, cross boundary with next chunk, i.e. { last-row-of-my-chunk , first-row-of-next }
+                int r = cmp->docompare(*rows, *(rows+1));
+                if (r)
+                    mark(i);
+            }
+            myEnd = getMore(myStart);
+            if (0 == myEnd)
+                break; // done
+        }
+    }
+public:
+    CMarker(CActivityBase &_activity) : activity(_activity)
+    {
+        cmp = NULL;
+        base = NULL;
+        startRow = endRow = chunkSize = next = 0;
+        unique = 0;
+        // perhaps should make configurable..
+        minForParallel = 100;
+        parallelMinChunkSize = 100;
+        parallelChunkSize = 10000;
+   }
+    unsigned calculate(CThorExpandingRowArray &rows, ICompare *_cmp)
+    {
+        cmp = _cmp;
+        unsigned threadCount = activity.getOptInt(THOROPT_JOINHELPER_THREADS, activity.queryMaxCores());
+        if (0 == threadCount)
+            threadCount = getAffinityCpus();
+        rowidx_t rowCount = rows.ordinality();
+        if (0 == rowCount)
+            return 0;
+        unique = 0;
+        startRow = next = 0;
+        endRow = startRow+rowCount;
+        base = rows.getRowArray();
+        bitSet.setown(createBitSet());
+        if (rowCount < minForParallel)
+        {
+            chunkSize = minForParallel;
+            rowidx_t s = startRow;
+            startRow = endRow;
+            run(s, endRow);
+        }
+        else
+        {
+            chunkSize = rowCount / threadCount;
+            if (chunkSize > parallelChunkSize)
+                chunkSize = parallelChunkSize;
+            else if (chunkSize < parallelMinChunkSize)
+            {
+                chunkSize = parallelMinChunkSize;
+                threadCount = rowCount / chunkSize;
+            }
+            for (unsigned t=0; t<threadCount; t++)
+            {
+                if (startRow+chunkSize >= endRow)
+                {
+                    threads.append(* new CCompareThread(*this, startRow, endRow));
+                    startRow = endRow;
+                    break;
+                }
+                else
+                {
+                    rowidx_t s = startRow;
+                    startRow += chunkSize;
+                    threads.append(* new CCompareThread(*this, s, startRow));
+                }
+            }
+            ForEachItemIn(t, threads)
+                threads.item(t).start();
+            ForEachItemIn(t2, threads)
+                threads.item(t2).join();
+            threads.kill();
+        }
+        mark(endRow-1); // last row is implicitly end of group
+        cmp = NULL;
+        return unique;
+    }
+    rowidx_t findNextBoundary()
+    {
+        if (next==endRow)
+            return 0;
+        rowidx_t ret = bitSet->scan(next, true);
+        next = ret+1;
+        return next;
+    }
+};
+
+
+template <class HELPER>
+class CAllOrLookupHelper
+{
+    HELPER *helper;
+public:
+    CAllOrLookupHelper() { }
+    void setHelper(HELPER *_helper)
+    {
+        helper = _helper;
+    }
+    inline bool match(const void *lhs, const void *rhsrow)
+    {
+        return helper->match(lhs, rhsrow);
+    }
+    inline const size32_t joinTransform(ARowBuilder &rowBuilder, const void *lhs, const void *rhsrow)
+    {
+        return helper->transform(rowBuilder, lhs, rhsrow);
+    }
+    inline const size32_t joinTransform(ARowBuilder &rowBuilder, const void *left, const void *right, unsigned numRows, const void **rows)
+    {
+        return helper->transform(rowBuilder, left, right, numRows, rows);
+    }
+    inline const size32_t joinTransform(ARowBuilder &rowBuilder, const void *left, const void *right, unsigned count)
+    {
+        return helper->transform(rowBuilder, left, right, count);
+    }
+};
+
+
 
 /* 
-    This activity loads the RIGHT hand stream into the hash table, therefore
+    These activity load the RIGHT hand stream into a table, therefore
     the right hand stream -should- contain the fewer records
 
     Inner, left outer and left only joins supported
-
 */
 
-
-/*
- * The main activity class
- * It's intended to be used when the RHS globally, is small enough to fit within the memory of a single node.
- * It performs the join, by 1st ensuring all RHS data is on all nodes, creating a hash table of this gathered set
- * then it streams the LHS through, matching against the RHS hash table entries.
- * It also handles match conditions where there is no hard match (, ALL), in those cases no hash table is needed.
- * TODO: right outer/only joins
+/* Base common to:
+ * 1) Lookup Many
+ * 2) Lookup
+ * 3) All
+ *
+ * Handles the initialization, broadcast and processing of RHS
  */
-class CLookupJoinActivity : public CSlaveActivity, public CThorDataLink, implements ISmartBufferNotify, implements IBCastReceive, implements roxiemem::IBufferedRowCallback
+template <class HTHELPER, class HELPER>
+class CInMemJoinBase : public CSlaveActivity, public CThorDataLink, implements ISmartBufferNotify, implements IBCastReceive
 {
-    IHThorHashJoinArg *hashJoinHelper;
-    IHThorAllJoinArg *allJoinHelper;
-    const void **rhsTable;
-    rowidx_t rhsTableLen, htCount, htDedupCount;
-    rowidx_t rhsRows;
-    IHash *leftHash, *rightHash;
-    ICompare *compareRight, *compareLeftRight;
+    CAllOrLookupHelper<HELPER> helper;
 
-    IThorDataLink *leftITDL, *rightITDL;
-    Owned<IRowStream> left, right;
-    Owned<IEngineRowAllocator> rightAllocator;
-    Owned<IEngineRowAllocator> leftAllocator;
-    Owned<IEngineRowAllocator> allocator;
-    Owned<IOutputRowSerializer> rightSerializer;
-    Owned<IOutputRowDeserializer> rightDeserializer;
-    bool gotRHS;
-    join_t joinType;
-    OwnedConstThorRow defaultRight;
-    OwnedConstThorRow leftRow;
-    Owned<IException> leftexception;
     Semaphore leftstartsem;
-    CThorExpandingRowArray rhs, ht;
-    bool eos, needGlobal;
-    unsigned flags;
-    bool exclude;
-    unsigned candidateMatches, abortLimit, atMost;
-    ConstPointerArray candidates;
-    unsigned candidateIndex;
-    const void *rhsNext;
-    Owned<IOutputMetaData> outputMeta;
-    rowcount_t rhsTotalCount;
-    mptag_t lhsDistributeTag, rhsDistributeTag, broadcast2MpTag;
+    Owned<IException> leftexception;
 
-    PointerArrayOf<CThorSpillableRowArray> rhsNodeRows;
-    CBroadcaster broadcaster;
+    bool eos, eog, someSinceEog;
 
-    // AllJoin only
-    rowidx_t nextRhsRow;
-    unsigned keepLimit;
-    unsigned joined;
-    OwnedConstThorRow defaultLeft;
-    Owned<IBitSet> rightMatchSet;
-
-    unsigned lastRightOuter;
-    bool doRightOuter;
-    bool eog, someSinceEog, leftMatch, grouped;
-    Semaphore gotOtherROs;
-    bool waitForOtherRO, fuzzyMatch, returnMany, dedup;
-
-    // Handling failover to a) hashed local lookupjoin b) hash distributed standard join
-    atomic_t spiltBroadcastingRHS;
-    CriticalSection broadcastSpillingLock;
-    bool localLookupJoin;
-    bool failoverToLocalLookupJoin, failoverToStdJoin;
-    rank_t myNode;
-    unsigned numNodes;
-    Owned<IHashDistributor> lhsDistributor, rhsDistributor;
-    ICompare *compareLeft;
-    Owned<IJoinHelper> joinHelper;
-    UnsignedArray flushedRowMarkers;
-
-    inline bool isLookup() const
-    {
-        switch (container.getKind())
-        {
-            case TAKlookupjoin:
-            case TAKlookupdenormalize:
-            case TAKlookupdenormalizegroup:
-            case TAKsmartjoin:
-            case TAKsmartdenormalize:
-            case TAKsmartdenormalizegroup:
-                return true;
-        }
-        return false;
-    }
-    inline bool isAll() const
-    {
-        switch (container.getKind())
-        {
-            case TAKalljoin:
-            case TAKalldenormalize:
-            case TAKalldenormalizegroup:
-                return true;
-        }
-        return false;
-    }
-    inline bool isDenormalize() const
-    {
-        switch (container.getKind())
-        {
-            case TAKlookupdenormalize:
-            case TAKlookupdenormalizegroup:
-            case TAKalldenormalize:
-            case TAKalldenormalizegroup:
-            case TAKsmartdenormalize:
-            case TAKsmartdenormalizegroup:
-                return true;
-        }
-        return false;
-    }
-    inline bool isGroupOp() const
-    {
-        switch (container.getKind())
-        {
-            case TAKlookupdenormalizegroup:
-            case TAKsmartdenormalizegroup:
-            case TAKalldenormalizegroup:
-                return true;
-        }
-        return false;
-    }
-    inline bool isSmart() const
-    {
-        switch (container.getKind())
-        {
-            case TAKsmartjoin:
-            case TAKsmartdenormalize:
-            case TAKsmartdenormalizegroup:
-                return true;
-        }
-        return false;
-    }
-    inline bool hasBroadcastSpilt() const { return 0 != atomic_read(&spiltBroadcastingRHS); }
-    inline void setBroadcastingSpilt(bool tf) { atomic_set(&spiltBroadcastingRHS, (int)tf); }
-
-    StringBuffer &getJoinTypeStr(StringBuffer &str)
-    {
-        switch(joinType)
-        {
-            case JT_Undefined:  return str.append("UNDEFINED");
-            case JT_Inner:      return str.append("INNER");
-            case JT_LeftOuter:  return str.append("LEFT OUTER");
-            case JT_RightOuter: return str.append("RIGHT OUTER");
-            case JT_LeftOnly:   return str.append("LEFT ONLY");
-            case JT_RightOnly:  return str.append("RIGHT ONLY");
-        }
-        return str.append("---> Unknown Join Type <---");
-    }
-    rowidx_t getHTSize(rowcount_t rows)
-    {
-        if (rows < 10) return 16;
-        rowcount_t res = rows/3*4; // make HT 1/3 bigger than # rows
-        if ((res < rows) || (res > RIMAX)) // check for overflow, or result bigger than rowidx_t size
-            throw MakeActivityException(this, 0, "Too many rows on RHS for hash table: %"RCPF"d", rows);
-        return (rowidx_t)res;
-    }
+protected:
     /* Utility class, that is called from the broadcaster to queue up received blocks
      * It will block if it has > MAX_QUEUE_BLOCKS to process (on the queue)
      * Processing will decompress the incoming blocks and add them to a row array per slave
@@ -609,12 +658,12 @@ class CLookupJoinActivity : public CSlaveActivity, public CThorDataLink, impleme
     class CRowProcessor : implements IThreaded
     {
         CThreadedPersistent threaded;
-        CLookupJoinActivity &owner;
+        CInMemJoinBase &owner;
         bool stopped;
         SimpleInterThreadQueueOf<CSendItem, true> blockQueue;
         Owned<IException> exception;
     public:
-        CRowProcessor(CLookupJoinActivity &_owner) : threaded("CRowProcessor", this), owner(_owner)
+        CRowProcessor(CInMemJoinBase &_owner) : threaded("CRowProcessor", this), owner(_owner)
         {
             stopped = false;
             blockQueue.setLimit(MAX_QUEUE_BLOCKS);
@@ -678,9 +727,80 @@ class CLookupJoinActivity : public CSlaveActivity, public CThorDataLink, impleme
         }
     } rowProcessor;
 
+    CBroadcaster broadcaster;
+    rowidx_t rhsTableLen;
+    HTHELPER table;
+    OwnedConstThorRow leftRow;
+
+    IThorDataLink *leftITDL, *rightITDL;
+    Owned<IRowStream> left, right;
+    Owned<IEngineRowAllocator> rightAllocator;
+    Owned<IEngineRowAllocator> leftAllocator;
+    Owned<IEngineRowAllocator> allocator;
+    Owned<IOutputRowSerializer> rightSerializer;
+    Owned<IOutputRowDeserializer> rightDeserializer;
+    bool gotRHS;
+    join_t joinType;
+    OwnedConstThorRow defaultRight;
+    CThorExpandingRowArray rhs;
+    bool needGlobal;
+    unsigned flags;
+    bool exclude;
+    const void *rhsNext;
+    Owned<IOutputMetaData> outputMeta;
+
+    PointerArrayOf<CThorSpillableRowArray> rhsNodeRows;
+
+    rowidx_t nextRhsRow;
+    unsigned keepLimit;
+    unsigned joined;
+    OwnedConstThorRow defaultLeft;
+
+    bool leftMatch, grouped;
+    bool fuzzyMatch, returnMany, dedup;
+    rank_t myNode;
+    unsigned numNodes;
+
+    inline bool isGroupOp() const
+    {
+        switch (container.getKind())
+        {
+            case TAKlookupdenormalizegroup:
+            case TAKsmartdenormalizegroup:
+            case TAKalldenormalizegroup:
+                return true;
+        }
+        return false;
+    }
+    inline bool isDenormalize() const
+    {
+        switch (container.getKind())
+        {
+            case TAKlookupdenormalize:
+            case TAKlookupdenormalizegroup:
+            case TAKalldenormalize:
+            case TAKalldenormalizegroup:
+            case TAKsmartdenormalize:
+            case TAKsmartdenormalizegroup:
+                return true;
+        }
+        return false;
+    }
+    StringBuffer &getJoinTypeStr(StringBuffer &str)
+    {
+        switch(joinType)
+        {
+            case JT_Undefined:  return str.append("UNDEFINED");
+            case JT_Inner:      return str.append("INNER");
+            case JT_LeftOuter:  return str.append("LEFT OUTER");
+            case JT_RightOuter: return str.append("RIGHT OUTER");
+            case JT_LeftOnly:   return str.append("LEFT ONLY");
+            case JT_RightOnly:  return str.append("RIGHT ONLY");
+        }
+        return str.append("---> Unknown Join Type <---");
+    }
     void clearRHS()
     {
-        ht.kill();
         rhs.kill();
         ForEachItemIn(a, rhsNodeRows)
         {
@@ -689,725 +809,17 @@ class CLookupJoinActivity : public CSlaveActivity, public CThorDataLink, impleme
                 rows->kill();
         }
     }
-public:
-    IMPLEMENT_IINTERFACE_USING(CSimpleInterface);
-
-    CLookupJoinActivity(CGraphElementBase *_container)
-        : CSlaveActivity(_container), CThorDataLink(this), broadcaster(*this), rhs(*this, NULL), ht(*this, NULL, true),
-          rowProcessor(*this)
+    void processRHSRows(unsigned slave, MemoryBuffer &mb)
     {
-        gotRHS = false;
-        nextRhsRow = 0;
-        rhsNext = NULL;
-        atMost = 0;
-        setBroadcastingSpilt(false);
-        localLookupJoin = false;
-        myNode = queryJob().queryMyRank();
-        numNodes = queryJob().querySlaves();
-        needGlobal = !container.queryLocal() && (container.queryJob().querySlaves() > 1);
-        broadcast2MpTag = lhsDistributeTag = rhsDistributeTag = TAG_NULL;
-
-        rhsTable = NULL;
-        rhsTableLen = htCount = htDedupCount = 0;
-        rhsRows = RIUNSET;
-        rhsTotalCount = RCUNSET;
-        leftITDL = rightITDL = NULL;
-        candidateIndex = 0;
-        candidateMatches = 0;
-
-        eos = false;
-        eog = someSinceEog = false;
-        joined = 0;
-        doRightOuter = false;
-        leftMatch = false;
-        grouped = false;
-        lastRightOuter = 0;
-        fuzzyMatch = returnMany = dedup = false;
-        waitForOtherRO = true;
-
-        hashJoinHelper = NULL;
-        allJoinHelper = NULL;
-        exclude = false;
-        abortLimit = keepLimit = 0;
-        allJoinHelper = NULL;
-        hashJoinHelper = NULL;
-        leftHash = rightHash = NULL;
-        hashJoinHelper = NULL;
-        compareLeft = compareRight = compareLeftRight = NULL;
-        dedup = false;
-
-        if (isAll())
+        CThorSpillableRowArray &rows = *rhsNodeRows.item(slave-1);
+        RtlDynamicRowBuilder rowBuilder(rightAllocator);
+        CThorStreamDeserializerSource memDeserializer(mb.length(), mb.toByteArray());
+        while (!memDeserializer.eos())
         {
-            allJoinHelper = (IHThorAllJoinArg *)queryHelper();
-            flags = allJoinHelper->getJoinFlags();
-            returnMany = true;
-            keepLimit = allJoinHelper->getKeepLimit();
-            fuzzyMatch = 0 != (JFmatchrequired & flags);
-        }
-        else
-        {
-            dbgassertex(isLookup());
-
-            hashJoinHelper = (IHThorHashJoinArg *)queryHelper();
-            flags = hashJoinHelper->getJoinFlags();
-            leftHash = hashJoinHelper->queryHashLeft();
-            rightHash = hashJoinHelper->queryHashRight();
-            compareRight = hashJoinHelper->queryCompareRight();
-            compareLeft = hashJoinHelper->queryCompareLeft();
-            compareLeftRight = hashJoinHelper->queryCompareLeftRight();
-            if (JFmanylookup & flags)
-                returnMany = true;
-            keepLimit = hashJoinHelper->getKeepLimit();
-            abortLimit = hashJoinHelper->getMatchAbortLimit();
-            atMost = hashJoinHelper->getJoinLimit();
-
-            fuzzyMatch = 0 != (JFmatchrequired & flags);
-            bool maySkip = 0 != (flags & JFtransformMaySkip);
-            dedup = compareRight && !maySkip && !fuzzyMatch && !returnMany;
-            if (compareRight && !maySkip && !fuzzyMatch)
-            {
-                if (returnMany)
-                    dedup = (1==keepLimit) && (0==atMost) && (0==abortLimit);
-                else
-                    dedup = true;
-            }
-            // code gen should spot invalid constants on KEEP with LOOKUP (without MANY)
-        }
-        exclude = 0 != (flags & JFexclude);
-        if(0 == keepLimit)
-            keepLimit = (unsigned)-1;
-        if (0 == abortLimit)
-            abortLimit = (unsigned)-1;
-        if (0 == atMost)
-            atMost = (unsigned)-1;
-        if (abortLimit < atMost)
-            atMost = abortLimit;
-
-        if (flags & JFleftouter)
-            joinType = exclude ? JT_LeftOnly : JT_LeftOuter;
-        else if (flags & JFrightouter)
-        {
-            UNIMPLEMENTED;
-            rightMatchSet.setown(createBitSet());
-            joinType = exclude ? JT_RightOnly : JT_RightOuter;
-        }
-        else
-            joinType = JT_Inner;
-        StringBuffer str;
-
-        failoverToLocalLookupJoin = failoverToStdJoin = isSmart();
-        ActPrintLog("Join type is %s, failoverToLocalLookupJoin=%s, failoverToStdJoin=%s",
-                getJoinTypeStr(str).str(), failoverToLocalLookupJoin?"true":"false", failoverToStdJoin?"true":"false");
-    }
-    ~CLookupJoinActivity()
-    {
-        ForEachItemIn(a, rhsNodeRows)
-        {
-            CThorSpillableRowArray *rows = rhsNodeRows.item(a);
-            if (rows)
-                delete rows;
-        }
-    }
-    rowidx_t clearNonLocalRows(CThorSpillableRowArray &rows, rowidx_t startPos)
-    {
-        rowidx_t clearedRows = 0;
-        rowidx_t numRows = rows.numCommitted();
-        for (unsigned r=startPos; r<numRows; r++)
-        {
-            unsigned hv = rightHash->hash(rows.query(r));
-            if ((myNode-1) != (hv % numNodes))
-            {
-                OwnedConstThorRow row = rows.getClear(r); // dispose of
-                ++clearedRows;
-            }
-        }
-        return clearedRows;
-    }
-    bool clearAllNonLocalRows(const char *msg)
-    {
-        // This is likely to free memory, so block others (threads) until done
-        // NB: This will not block appends
-        CriticalBlock b(broadcastSpillingLock);
-        if (hasBroadcastSpilt())
-            return false;
-        setBroadcastingSpilt(true);
-
-        ActPrintLog("Clearing non-local rows - cause: %s", msg);
-
-        /* NB: It is likely that there will be unflushed rows in the rhsNodeRows arrays after we are done here.
-        /* These will need flushing when all is done and clearNonLocalRows will need recalling to process rest
-         */
-
-        rowidx_t clearedRows = 0;
-        ForEachItemIn(a, rhsNodeRows)
-        {
-            CThorSpillableRowArray &rows = *rhsNodeRows.item(a);
-
-            /* Record point to which clearNonLocalRows will reach
-             * so that can resume from that point, when done adding/flushing
-             */
-            flushedRowMarkers.append(rows.numCommitted());
-            clearedRows += clearNonLocalRows(rows, 0);
-        }
-        ActPrintLog("handleLowMem: clearedRows = %"RIPF"d", clearedRows);
-        return 0 != clearedRows;
-    }
-
-// IThorSlaveActivity overloaded methods
-    virtual void init(MemoryBuffer &data, MemoryBuffer &slaveData)
-    {
-        appendOutputLinked(this);
-
-        if (!container.queryLocal())
-        {
-            mpTag = container.queryJob().deserializeMPTag(data);
-            broadcast2MpTag = container.queryJob().deserializeMPTag(data);
-            lhsDistributeTag = container.queryJob().deserializeMPTag(data);
-            rhsDistributeTag = container.queryJob().deserializeMPTag(data);
-        }
-
-        unsigned slaves = container.queryJob().querySlaves();
-        rhsNodeRows.ensure(slaves);
-        while (slaves--)
-            rhsNodeRows.append(new CThorSpillableRowArray(*this, NULL));
-    }
-    virtual void onInputStarted(IException *except)
-    {
-        leftexception.set(except);
-        leftstartsem.signal();
-    }
-    virtual bool startAsync()
-    {
-        return true;
-    }
-    virtual void onInputFinished(rowcount_t count)
-    {
-        ActPrintLog("LHS input finished, %"RCPF"d rows read", count);
-    }
-    virtual void start()
-    {
-        ActivityTimer s(totalCycles, timeActivities, NULL);
-        assertex(inputs.ordinality() == 2);
-        gotRHS = false;
-        nextRhsRow = 0;
-        joined = 0;
-        leftMatch = false;
-        rhsNext = NULL;
-        candidateMatches = 0;
-        rhsTotalCount = RCUNSET;
-        htCount = htDedupCount = 0;
-        rhsTableLen = 0;
-        rhsRows = RIUNSET;
-        eos = eog = someSinceEog = false;
-        leftITDL = inputs.item(0);
-        rightITDL = inputs.item(1);
-        allocator.set(queryRowAllocator());
-        leftAllocator.set(::queryRowAllocator(leftITDL));
-        outputMeta.set(leftITDL->queryFromActivity()->queryContainer().queryHelper()->queryOutputMeta());
-
-        right.set(rightITDL);
-        rightAllocator.set(::queryRowAllocator(rightITDL));
-        rightSerializer.set(::queryRowSerializer(rightITDL));
-        rightDeserializer.set(::queryRowDeserializer(rightITDL));
-
-        setBroadcastingSpilt(false);
-        localLookupJoin = false;
-        flushedRowMarkers.kill();
-
-        if (failoverToLocalLookupJoin && hashJoinHelper) // only for LOOKUP not ALL
-        {
-            if (needGlobal)
-                queryJob().queryRowManager()->addRowBuffer(this);
-        }
-
-        RtlDynamicRowBuilder rr(rightAllocator);
-        if ((flags & JFonfail) || (flags & JFleftouter))
-            rr.ensureRow();
-        RtlDynamicRowBuilder rl(leftAllocator);
-        if (flags & JFrightouter)
-            rl.ensureRow();
-        size32_t rrsz=0;
-        size32_t rlsz=0;
-
-        if (isAll())
-        {
-            if (rr.exists())
-                rrsz = allJoinHelper->createDefaultRight(rr);
-            if (rl.exists())
-                rlsz = allJoinHelper->createDefaultLeft(rl);
-            grouped = allJoinHelper->queryOutputMeta()->isGrouped();
-        }
-        else
-        {
-            dbgassertex(isLookup());
-            if (rr.exists())
-                rrsz = hashJoinHelper->createDefaultRight(rr);
-            if (rl.exists())
-                rlsz = hashJoinHelper->createDefaultLeft(rl);
-            grouped = hashJoinHelper->queryOutputMeta()->isGrouped();
-        }
-
-        leftITDL = createDataLinkSmartBuffer(this,leftITDL,LOOKUPJOINL_SMART_BUFFER_SIZE,isSmartBufferSpillNeeded(leftITDL->queryFromActivity()),grouped,RCUNBOUND,this,false,&container.queryJob().queryIDiskUsage());
-        left.setown(leftITDL);
-        startInput(leftITDL);
-
-        try
-        {
-            if (isLookup() && !isSmart())
-            {
-                bool inputGrouped = leftITDL->isGrouped();
-                dbgassertex(inputGrouped == grouped); // std. lookup join expects these to match
-            }
-
-            if (rrsz)
-                defaultRight.setown(rr.finalizeRowClear(rrsz));
-            if (rlsz)
-                defaultLeft.setown(rl.finalizeRowClear(rlsz));
-
-            startInput(rightITDL);
-        }
-        catch (CATCHALL)
-        {
-            leftstartsem.wait();
-            left->stop();
-            throw;
-        }
-        leftstartsem.wait();
-        if (leftexception)
-        {
-            right->stop();
-            throw leftexception.getClear();
-        }
-        dataLinkStart();
-    }
-    virtual void abort()
-    {
-        CSlaveActivity::abort();
-        gotOtherROs.signal();
-        cancelReceiveMsg(RANK_ALL, mpTag);
-        broadcaster.cancel();
-        rowProcessor.abort();
-        if (rhsDistributor)
-            rhsDistributor->abort();
-        if (lhsDistributor)
-            lhsDistributor->abort();
-    }
-    virtual void stop()
-    {
-        if (!gotRHS && needGlobal)
-            getRHS(true); // If global, need to handle RHS until all are slaves stop
-
-        // JCS->GH - if in a child query, it would be good to preserve RHS.. would need tip/flag from codegen that constant
-        clearRHS();
-
-        if (right)
-        {
-            stopInput(right, "(R)");
-            right.clear();
-        }
-        broadcaster.reset();
-        stopInput(left, "(L)");
-        left.clear();
-        if (rhsDistributor)
-        {
-            rhsDistributor->disconnect(true);
-            rhsDistributor->join();
-        }
-        if (lhsDistributor)
-        {
-            lhsDistributor->disconnect(true);
-            lhsDistributor->join();
-        }
-        joinHelper.clear();
-        dataLinkStop();
-    }
-    inline bool match(const void *lhs, const void *rhsrow)
-    {
-        if (isAll())
-            return allJoinHelper->match(lhs, rhsrow);
-        else
-        {
-            dbgassertex(isLookup());
-            return hashJoinHelper->match(lhs, rhsrow);
-        }
-    }
-    inline const void *joinTransform(const void *lhs, const void *rhsrow)
-    {
-        RtlDynamicRowBuilder row(allocator);
-        size32_t thisSize;
-        switch (container.getKind())
-        {
-            case TAKalljoin:
-            case TAKalldenormalize:
-                thisSize = allJoinHelper->transform(row, lhs, rhsrow);
-                break;
-            case TAKlookupjoin:
-            case TAKlookupdenormalize:
-            case TAKsmartjoin:
-            case TAKsmartdenormalize:
-                thisSize = hashJoinHelper->transform(row, lhs, rhsrow);
-                break;
-            default:
-                throwUnexpected();
-        }
-        if (thisSize)
-            return row.finalizeRowClear(thisSize);
-        return NULL;
-    }
-    // find routines for lookup only (compareRight!=NULL), ALL will not call
-    const void *find(const void *r, unsigned &h) 
-    {
-        loop
-        {
-            const void *e = rhsTable[h];
-            if (!e) 
-                break;
-            if (0 == compareLeftRight->docompare(r,e))
-                return e;
-            h++;
-            if (h>=rhsTableLen)
-                h = 0;
-        }
-        return NULL;
-    }
-    const void *findFirst(const void *r, unsigned &h) 
-    {
-        h = leftHash->hash(r)%rhsTableLen;
-        return find(r, h);
-    }
-    const void *findNext(const void *r, unsigned &h) 
-    {
-        h++;
-        if (h>=rhsTableLen)
-            h = 0;
-        return find(r, h);
-    }
-    void prepareRightOnly()
-    {
-        assertex(!doRightOuter);
-
-        // will have to merge rhsMatchSets in a tree as there can be a large number of outer records per node.
-        // topn does something similar, reuse.
-        // when all merged, have complete merged set on node 0 only.
-        // either output all from node 0, or partition set and distribute partition info to each node for output.
-
-        // If right only, no need to broadcast rhs record set, can look for matches in local input and merge match etc. set as above.
-
-        doRightOuter = true;
-        gotOtherROs.signal();
-    }
-    const void *handleRightOnly()
-    {
-        if (waitForOtherRO)
-        {
-            gotOtherROs.wait();         
-            waitForOtherRO = false;
-        }       
-        if (eog)
-        {
-            loop
-            {
-                if (nextRhsRow >= rhsRows)
-                    break;
-                bool setNext = (nextRhsRow < lastRightOuter);
-                if (setNext)
-                {
-                    nextRhsRow = rightMatchSet->scan(nextRhsRow, false);
-                    if (nextRhsRow >= rhsRows) break;
-                }
-                OwnedConstThorRow row = joinTransform(defaultLeft, rhsTable[nextRhsRow]);
-                if (!setNext)
-                    nextRhsRow++;
-                if (row)
-                {
-                    eog = false;
-                    return row.getClear();
-                }
-            }
-            eos = true;
-        }
-        eog = true;
-        return NULL;
-    }
-    inline void nextRhs()
-    {
-        if ((unsigned)-1 != atMost)
-            rhsNext = candidateIndex < candidates.ordinality() ? candidates.item(candidateIndex++) : NULL;
-        else if (isLookup())
-            rhsNext = findNext(leftRow, nextRhsRow);
-        else if (++nextRhsRow<rhsRows)
-            rhsNext = rhsTable[nextRhsRow];
-        else
-            rhsNext = NULL;
-    }
-    CATCH_NEXTROW()
-    {
-        ActivityTimer t(totalCycles, timeActivities, NULL);
-        if (!gotRHS)
-            getRHS(false);
-        OwnedConstThorRow row;
-        if (joinHelper) // regular join (hash join)
-            row.setown(joinHelper->nextRow());
-        else
-            row.setown(lookupNextRow());
-        if (!row.get())
-            return NULL;
-        dataLinkIncrement();
-        return row.getClear();
-    }
-    const void *lookupNextRow()
-    {
-        if (!abortSoon && !eos)
-        {
-            if (doRightOuter)
-            {
-                OwnedConstThorRow row = handleRightOnly();
-                if (row)
-                    return row.getClear();
-                return NULL;
-            }
-            loop
-            {
-                if (NULL == rhsNext)
-                {
-                    nextRhsRow = 0;
-                    joined = 0;
-                    candidateMatches = 0;
-                    leftMatch = false;
-                    if ((unsigned)-1 != atMost)
-                    {
-                        candidates.kill();
-                        candidateIndex = 1;
-                    }
-                    leftRow.setown(left->nextRow());
-                    if (leftRow)
-                    {
-                        eog = false;
-                        if (rhsRows)
-                        {
-                            if (isAll())
-                                rhsNext = rhsTable[nextRhsRow];
-                            else
-                            {
-                                rhsNext = findFirst(leftRow, nextRhsRow);
-                                if ((unsigned)-1 != atMost) // have to build candidates to know
-                                {
-                                    while (rhsNext)
-                                    {
-                                        ++candidateMatches;
-                                        if (candidateMatches>abortLimit)
-                                        {
-                                            if (0 == (JFmatchAbortLimitSkips & flags))
-                                            {
-                                                Owned<IException> e;
-                                                try
-                                                {
-                                                    if (hashJoinHelper)
-                                                        hashJoinHelper->onMatchAbortLimitExceeded();
-                                                    CommonXmlWriter xmlwrite(0);
-                                                    if (outputMeta && outputMeta->hasXML())
-                                                    {
-                                                        outputMeta->toXML((const byte *) leftRow.get(), xmlwrite);
-                                                    }
-                                                    throw MakeActivityException(this, 0, "More than %d match candidates in join for row %s", abortLimit, xmlwrite.str());
-                                                }
-                                                catch (IException *_e)
-                                                {
-                                                    if (0 == (JFonfail & flags))
-                                                        throw;
-                                                    e.setown(_e);
-                                                }
-                                                RtlDynamicRowBuilder ret(allocator);
-                                                size32_t transformedSize = hashJoinHelper->onFailTransform(ret, leftRow, defaultRight, e.get());
-                                                rhsNext = NULL;
-                                                if (transformedSize)
-                                                {
-                                                    candidateMatches = 0;
-                                                    return ret.finalizeRowClear(transformedSize);
-                                                }
-                                            }
-                                            else
-                                                leftMatch = true; // there was a lhs match, even though rhs group exceeded limit. Therefore this lhs will not be considered left only/left outer
-                                            candidateMatches = 0;
-                                            break;
-                                        }
-                                        else if (candidateMatches>atMost)
-                                        {
-                                            candidateMatches = 0;
-                                            break;
-                                        }
-                                        candidates.append(rhsNext);
-                                        rhsNext = findNext(leftRow, nextRhsRow);
-                                    }                               
-                                    if (0 == candidateMatches)
-                                        rhsNext = NULL;
-                                    else if (candidates.ordinality())
-                                        rhsNext = candidates.item(0);
-                                }
-                            }
-                        }
-                    }
-                    else
-                    {
-                        if (eog)
-                        {
-                            if (flags & JFrightouter)
-                            {
-                                prepareRightOnly();
-                                OwnedConstThorRow row = handleRightOnly();
-                                if (row)
-                                    return row.getClear();
-                            }
-                            else
-                                eos = true;
-                        }
-                        else
-                        {
-                            eog = true;
-                            if (!someSinceEog)
-                                continue; // skip empty 'group'
-                            someSinceEog = false;
-                        }
-                        break;
-                    }
-                }
-                if (isDenormalize())
-                {
-                    OwnedConstThorRow ret;
-                    RtlDynamicRowBuilder tmpbuf(allocator);
-                    unsigned rcCount = 0;
-                    ConstPointerArray filteredRhs;
-                    while (rhsNext)
-                    {
-                        if (abortSoon) 
-                            return NULL;
-                        if (!fuzzyMatch || (isAll()?allJoinHelper->match(leftRow, rhsNext):hashJoinHelper->match(leftRow, rhsNext)))
-                        {
-                            leftMatch = true;
-                            if (exclude)
-                            {
-                                rhsNext = NULL;
-                                break;
-                            }
-                            ++joined;
-                            filteredRhs.append(rhsNext);
-                        }
-                        if (!returnMany || joined == keepLimit)
-                        {
-                            rhsNext = NULL;
-                            break;
-                        }
-                        nextRhs();
-                    }
-                    if (filteredRhs.ordinality() || (!leftMatch && 0!=(flags & JFleftouter)))
-                    {
-                        unsigned numRows = filteredRhs.ordinality();
-                        const void *rightRow = numRows ? filteredRhs.item(0) : defaultRight.get();
-                        if (isGroupOp())
-                        {
-                            size32_t sz = isAll()?allJoinHelper->transform(tmpbuf, leftRow, rightRow, numRows, filteredRhs.getArray()):hashJoinHelper->transform(tmpbuf, leftRow, rightRow, numRows, filteredRhs.getArray());
-                            if (sz)
-                                ret.setown(tmpbuf.finalizeRowClear(sz));
-                        }
-                        else
-                        {
-                            ret.set(leftRow);
-                            if (filteredRhs.ordinality())
-                            {
-                                size32_t rowSize = 0;
-                                loop
-                                {
-                                    const void *rightRow = filteredRhs.item(rcCount);
-                                    size32_t sz = isAll()?allJoinHelper->transform(tmpbuf, ret, rightRow, ++rcCount):hashJoinHelper->transform(tmpbuf, ret, rightRow, ++rcCount);
-                                    if (sz)
-                                    {
-                                        rowSize = sz;
-                                        ret.setown(tmpbuf.finalizeRowClear(sz));
-                                    }
-                                    if (rcCount == filteredRhs.ordinality())
-                                        break;
-                                    tmpbuf.ensureRow();
-                                }
-                                if (!rowSize)
-                                    ret.clear();
-                            }
-                        }
-                    }
-                    if (ret)
-                    {
-                        someSinceEog = true;
-                        return ret.getClear();
-                    }
-                }
-                else
-                {
-                    while (rhsNext)
-                    {
-                        if (!fuzzyMatch || match(leftRow, rhsNext))
-                        {
-                            leftMatch = true;
-                            if (!exclude)
-                            {
-                                OwnedConstThorRow row = joinTransform(leftRow, rhsNext);
-                                if (row)
-                                {
-                                    someSinceEog = true;
-                                    if (++joined == keepLimit)
-                                        rhsNext = NULL;
-                                    else if (!returnMany)
-                                        rhsNext = NULL;
-                                    else
-                                        nextRhs();
-                                    return row.getClear();
-                                }
-                            }
-                        }
-                        else if (flags & JFrightouter)
-                            rightMatchSet->set(nextRhsRow);
-                        nextRhs();
-                    }
-                    if (!leftMatch && NULL == rhsNext && 0!=(flags & JFleftouter))
-                    {
-                        OwnedConstThorRow row = joinTransform(leftRow, defaultRight);
-                        if (row)
-                        {
-                            someSinceEog = true;
-                            return row.getClear();
-                        }
-                    }
-                }
-            }
-        }
-        return NULL;
-    }
-    virtual bool isGrouped() { return inputs.item(0)->isGrouped(); }
-    void getMetaInfo(ThorDataLinkMetaInfo &info)
-    {
-        initMetaInfo(info);
-        info.unknownRowsOutput = true;
-        info.canStall = true;
-    }
-    void addRowHt(const void *p)
-    {
-        OwnedConstThorRow _p = p;
-        unsigned h = rightHash->hash(p)%rhsTableLen;
-        loop
-        {
-            const void *e = ht.query(h);
-            if (!e)
-            {
-                ht.setRow(h, _p.getClear());
-                htCount++;
-                break;
-            }
-            if (dedup && 0 == compareRight->docompare(e,p))
-            {
-                htDedupCount++;
-                break; // implicit dedup
-            }
-            h++;
-            if (h>=rhsTableLen)
-                h = 0;
+            size32_t sz = rightDeserializer->deserialize(rowBuilder, memDeserializer);
+            OwnedConstThorRow fRow = rowBuilder.finalizeRowClear(sz);
+            // NB: If spilt, addLocalRHSRow will filter out non-locals
+            addLocalRHSRow(rows, fRow);
         }
     }
     void broadcastRHS() // broadcasting local rhs
@@ -1427,31 +839,8 @@ public:
                     if (!row)
                         break;
 
-                    {
-                        if (hasBroadcastSpilt())
-                        {
-                            // keep it only if it hashes to my node
-                            unsigned hv = rightHash->hash(row.get());
-                            if ((myNode-1) == (hv % numNodes))
-                                localRhsRows.append(row.getLink());
-
-                            // ok so switch tactics.
-                            // clearAllNonLocalRows() will have cleared out non-locals by now
-                            // but I may be half way through serializing rows here, which are mixed and this row
-                            // may still need to be sent.
-                            // The destination rowProcessor will take care of any that need post-filtering,
-                            // so ensure last buffer is sent, below before exiting broadcastRHS broadcast
-
-                            stopRHSBroadcast = true;
-                        }
-                        else
-                        {
-                            /* NB: It could still spill here, i.e. before appending a non-local row
-                             * When all is done, a last pass is needed to clear out non-locals
-                             */
-                            localRhsRows.append(row.getLink());
-                        }
-                    }
+                    if (!addLocalRHSRow(localRhsRows, row))
+                        stopRHSBroadcast = true;
 
                     rightSerializer->serialize(mbser, (const byte *)row.get());
                     if (mb.length() >= MAX_SEND_SIZE || stopRHSBroadcast)
@@ -1472,7 +861,7 @@ public:
         }
         catch (IException *e)
         {
-            ActPrintLog(e, "CLookupJoinActivity::broadcastRHS: exception");
+            ActPrintLog(e, "CInMemJoinBase::broadcastRHS: exception");
             throw;
         }
 
@@ -1482,34 +871,501 @@ public:
         ActPrintLog("Sending final RHS broadcast packet");
         broadcaster.send(sendItem); // signals stop to others
     }
-    void processRHSRows(unsigned slave, MemoryBuffer &mb)
+    inline void resetRhsNext()
     {
-        CThorSpillableRowArray &rows = *rhsNodeRows.item(slave-1);
-        RtlDynamicRowBuilder rowBuilder(rightAllocator);
-        CThorStreamDeserializerSource memDeserializer(mb.length(), mb.toByteArray());
-        while (!memDeserializer.eos())
+        nextRhsRow = 0;
+        joined = 0;
+        leftMatch = false;
+    }
+    inline const void *denormalizeNextRow()
+    {
+        ConstPointerArray filteredRhs;
+        while (rhsNext)
         {
-            size32_t sz = rightDeserializer->deserialize(rowBuilder, memDeserializer);
-            OwnedConstThorRow fRow = rowBuilder.finalizeRowClear(sz);
-            if (hasBroadcastSpilt())
+            if (abortSoon)
+                return NULL;
+            if (!fuzzyMatch || (helper.match(leftRow, rhsNext)))
             {
-                /* NB: recvLoop should be winding down, a slave signal spilt and communicated to all
-                 * So these will be the last few broadcast rows, when broadcaster is complete, the rest will be hash distributed
-                 */
-
-                // hash row and discard unless for this node
-                unsigned hv = rightHash->hash(fRow.get());
-                if ((myNode-1) == (hv % numNodes))
-                    rows.append(fRow.getClear());
+                leftMatch = true;
+                if (exclude)
+                {
+                    rhsNext = NULL;
+                    break;
+                }
+                ++joined;
+                filteredRhs.append(rhsNext);
+            }
+            if (!returnMany || joined == keepLimit)
+            {
+                rhsNext = NULL;
+                break;
+            }
+            rhsNext = table.getNextRHS();
+        }
+        if (filteredRhs.ordinality() || (!leftMatch && 0!=(flags & JFleftouter)))
+        {
+            unsigned rcCount = 0;
+            OwnedConstThorRow ret;
+            RtlDynamicRowBuilder rowBuilder(allocator);
+            unsigned numRows = filteredRhs.ordinality();
+            const void *rightRow = numRows ? filteredRhs.item(0) : defaultRight.get();
+            if (isGroupOp())
+            {
+                size32_t sz = helper.joinTransform(rowBuilder, leftRow, rightRow, numRows, filteredRhs.getArray());
+                if (sz)
+                    ret.setown(rowBuilder.finalizeRowClear(sz));
             }
             else
             {
-                /* NB: It could still spill here, i.e. before appending a non-local row
-                 * When all is done, a last pass is needed to clear out non-locals
-                 */
-                rows.append(fRow.getClear());
+                ret.set(leftRow);
+                if (filteredRhs.ordinality())
+                {
+                    size32_t rowSize = 0;
+                    loop
+                    {
+                        const void *rightRow = filteredRhs.item(rcCount);
+                        size32_t sz = helper.joinTransform(rowBuilder, ret, rightRow, ++rcCount);
+                        if (sz)
+                        {
+                            rowSize = sz;
+                            ret.setown(rowBuilder.finalizeRowClear(sz));
+                        }
+                        if (rcCount == filteredRhs.ordinality())
+                            break;
+                        rowBuilder.ensureRow();
+                    }
+                    if (!rowSize)
+                        ret.clear();
+                }
+            }
+            return ret.getClear();
+        }
+        else
+            return NULL;
+    }
+    const void *lookupNextRow()
+    {
+        if (!abortSoon && !eos)
+        {
+            loop
+            {
+                if (NULL == rhsNext)
+                {
+                    leftRow.setown(left->nextRow());
+                    if (leftRow)
+                    {
+                        eog = false;
+                        if (rhsTableLen)
+                        {
+                            resetRhsNext();
+                            const void *failRow = NULL;
+                            rhsNext = table.getFirstRHSMatch(leftRow, failRow); // also checks abortLimit/atMost
+                            if (failRow)
+                                return failRow;
+                        }
+                    }
+                    else
+                    {
+                        if (eog)
+                            eos = true;
+                        else
+                        {
+                            eog = true;
+                            if (!someSinceEog)
+                                continue; // skip empty 'group'
+                            someSinceEog = false;
+                        }
+                        break;
+                    }
+                }
+                OwnedConstThorRow ret;
+                if (isDenormalize())
+                    ret.setown(denormalizeNextRow());
+                else
+                {
+                    RtlDynamicRowBuilder rowBuilder(allocator);
+                    while (rhsNext)
+                    {
+                        if (!fuzzyMatch || helper.match(leftRow, rhsNext))
+                        {
+                            leftMatch = true;
+                            if (!exclude)
+                            {
+                                size32_t sz = helper.joinTransform(rowBuilder, leftRow, rhsNext);
+                                if (sz)
+                                {
+                                    OwnedConstThorRow row = rowBuilder.finalizeRowClear(sz);
+                                    someSinceEog = true;
+                                    if (++joined == keepLimit)
+                                        rhsNext = NULL;
+                                    else if (!returnMany)
+                                        rhsNext = NULL;
+                                    else
+                                        rhsNext = table.getNextRHS();
+                                    return row.getClear();
+                                }
+                            }
+                        }
+                        rhsNext = table.getNextRHS();
+                    }
+                    if (!leftMatch && NULL == rhsNext && 0!=(flags & JFleftouter))
+                    {
+                        size32_t sz = helper.joinTransform(rowBuilder, leftRow, defaultRight);
+                        if (sz)
+                            ret.setown(rowBuilder.finalizeRowClear(sz));
+                    }
+                }
+                if (ret)
+                {
+                    someSinceEog = true;
+                    return ret.getClear();
+                }
             }
         }
+        return NULL;
+    }
+public:
+    IMPLEMENT_IINTERFACE_USING(CSimpleInterface);
+
+    CInMemJoinBase(CGraphElementBase *_container) : CSlaveActivity(_container), CThorDataLink(this),
+        broadcaster(*this), rhs(*this, NULL), rowProcessor(*this)
+    {
+        helper.setHelper((HELPER *)queryHelper());
+        gotRHS = false;
+        nextRhsRow = 0;
+        rhsNext = NULL;
+        myNode = queryJob().queryMyRank();
+        numNodes = queryJob().querySlaves();
+        needGlobal = !container.queryLocal() && (container.queryJob().querySlaves() > 1);
+
+        rhsTableLen = 0;
+        leftITDL = rightITDL = NULL;
+
+        joined = 0;
+        leftMatch = false;
+        grouped = false;
+        fuzzyMatch = returnMany = false;
+
+        exclude = false;
+        keepLimit = 0;
+        flags = 0;
+        joinType = JT_Undefined;
+        dedup = false;
+
+        eos = eog = someSinceEog = false;
+    }
+    ~CInMemJoinBase()
+    {
+        ForEachItemIn(a, rhsNodeRows)
+        {
+            CThorSpillableRowArray *rows = rhsNodeRows.item(a);
+            if (rows)
+                delete rows;
+        }
+    }
+// IThorSlaveActivity overloaded methods
+    virtual void init(MemoryBuffer &data, MemoryBuffer &slaveData)
+    {
+        appendOutputLinked(this);
+
+        exclude = 0 != (flags & JFexclude);
+        if (0 == keepLimit)
+            keepLimit = (unsigned)-1;
+        if (flags & JFleftouter)
+            joinType = exclude ? JT_LeftOnly : JT_LeftOuter;
+        else
+            joinType = JT_Inner;
+        StringBuffer str;
+        ActPrintLog("Join type is %s", getJoinTypeStr(str).str());
+
+        if (!container.queryLocal())
+            mpTag = container.queryJob().deserializeMPTag(data);
+
+        unsigned slaves = container.queryJob().querySlaves();
+        rhsNodeRows.ensure(slaves);
+        while (slaves--)
+            rhsNodeRows.append(new CThorSpillableRowArray(*this, NULL));
+    }
+    virtual void start()
+    {
+        assertex(inputs.ordinality() == 2);
+        gotRHS = false;
+        nextRhsRow = 0;
+        joined = 0;
+        leftMatch = false;
+        rhsNext = NULL;
+        rhsTableLen = 0;
+        leftITDL = inputs.item(0);
+        rightITDL = inputs.item(1);
+        allocator.set(queryRowAllocator());
+        leftAllocator.set(::queryRowAllocator(leftITDL));
+        outputMeta.set(leftITDL->queryFromActivity()->queryContainer().queryHelper()->queryOutputMeta());
+
+        eos = eog = someSinceEog = false;
+
+        right.set(rightITDL);
+        rightAllocator.set(::queryRowAllocator(rightITDL));
+        rightSerializer.set(::queryRowSerializer(rightITDL));
+        rightDeserializer.set(::queryRowDeserializer(rightITDL));
+
+        leftITDL = createDataLinkSmartBuffer(this,leftITDL,LOOKUPJOINL_SMART_BUFFER_SIZE,isSmartBufferSpillNeeded(leftITDL->queryFromActivity()),grouped,RCUNBOUND,this,false,&container.queryJob().queryIDiskUsage());
+        left.setown(leftITDL);
+        startInput(leftITDL);
+
+        try
+        {
+            startInput(rightITDL);
+        }
+        catch (CATCHALL)
+        {
+            leftstartsem.wait();
+            left->stop();
+            throw;
+        }
+        leftstartsem.wait();
+        if (leftexception)
+        {
+            right->stop();
+            throw leftexception.getClear();
+        }
+        dataLinkStart();
+    }
+    virtual void abort()
+    {
+        CSlaveActivity::abort();
+        cancelReceiveMsg(RANK_ALL, mpTag);
+        broadcaster.cancel();
+        rowProcessor.abort();
+    }
+    virtual void stop()
+    {
+        // JCS->GH - if in a child query, it would be good to preserve RHS.. would need tip/flag from codegen that constant
+        clearRHS();
+        if (right)
+        {
+            stopInput(right, "(R)");
+            right.clear();
+        }
+        broadcaster.reset();
+        stopInput(left, "(L)");
+        left.clear();
+        dataLinkStop();
+    }
+    virtual void getMetaInfo(ThorDataLinkMetaInfo &info)
+    {
+        initMetaInfo(info);
+        info.unknownRowsOutput = true;
+        info.canStall = true;
+    }
+    void doBroadcastRHS(bool stopping)
+    {
+        rowProcessor.start();
+        broadcaster.start(this, mpTag, stopping);
+        broadcastRHS();
+        broadcaster.end();
+        rowProcessor.wait();
+    }
+    rowidx_t getGlobalRHSTotal()
+    {
+        rowcount_t rhsRows = 0;
+        ForEachItemIn(a, rhsNodeRows)
+        {
+            CThorSpillableRowArray &rows = *rhsNodeRows.item(a);
+            rows.flush();
+            rhsRows += rows.numCommitted();
+            if (rhsRows > RIMAX)
+                throw MakeActivityException(this, 0, "Too many RHS rows: %"RCPF"d", rhsRows);
+        }
+        return (rowidx_t)rhsRows;
+    }
+    virtual bool addLocalRHSRow(CThorSpillableRowArray &localRhsRows, const void *row)
+    {
+        LinkThorRow(row);
+        localRhsRows.append(row);
+        return true;
+    }
+// ISmartBufferNotify
+    virtual void onInputStarted(IException *except)
+    {
+        leftexception.set(except);
+        leftstartsem.signal();
+    }
+    virtual bool startAsync()
+    {
+        return true;
+    }
+    virtual void onInputFinished(rowcount_t count)
+    {
+        ActPrintLog("LHS input finished, %"RCPF"d rows read", count);
+    }
+};
+
+
+
+/* Base class for:
+ * 1) Lookup Many
+ * 2) Lookup
+ * They use different hash table representations, Lookup Many represents entries as {index, count}
+ * Where as Lookup represents as simply hash table to rows
+ * The main activity class
+ * Both varieties do common work in this base class
+ *
+ * It performs the join, by 1st ensuring all RHS data is on all nodes, creating a hash table of this gathered set
+ * then it streams the LHS through, matching against the RHS hash table entries.
+ * It also handles match conditions where there is no hard match (, ALL), in those cases no hash table is needed.
+ *
+ * This base class also handles the 'SMART' functionality.
+ * If RHS doesn't fit into memory, this class handles failover to local lookupjoin, by hashing the RHS to local
+ * and hash distributing the LHS.
+ * If the local RHS table still doesn't fit into memory, it will failover to a standard hash join, i.e. it will
+ * need to sort both sides
+ *
+ * TODO: right outer/only joins
+ */
+
+template <class HTHELPER>
+class CLookupJoinActivityBase : public CInMemJoinBase<HTHELPER, IHThorHashJoinArg>, implements roxiemem::IBufferedRowCallback
+{
+    typedef CInMemJoinBase<HTHELPER, IHThorHashJoinArg> PARENT;
+protected:
+    using PARENT::container;
+    using PARENT::myNode;
+    using PARENT::numNodes;
+    using PARENT::ActPrintLog;
+    using PARENT::rhs;
+    using PARENT::right;
+    using PARENT::left;
+    using PARENT::rightITDL;
+    using PARENT::leftITDL;
+    using PARENT::rhsNodeRows;
+    using PARENT::rhsTableLen;
+    using PARENT::table;
+    using PARENT::flags;
+    using PARENT::outputMeta;
+    using PARENT::leftMatch;
+    using PARENT::gotRHS;
+    using PARENT::needGlobal;
+    using PARENT::leftRow;
+    using PARENT::allocator;
+    using PARENT::defaultRight;
+    using PARENT::grouped;
+    using PARENT::abortSoon;
+    using PARENT::leftAllocator;
+    using PARENT::rightAllocator;
+    using PARENT::returnMany;
+    using PARENT::fuzzyMatch;
+    using PARENT::keepLimit;
+    using PARENT::dedup;
+    using PARENT::doBroadcastRHS;
+    using PARENT::getGlobalRHSTotal;
+    using PARENT::getOptBool;
+    using PARENT::broadcaster;
+    using PARENT::inputs;
+    using PARENT::queryHelper;
+    using PARENT::totalCycles;
+    using PARENT::timeActivities;
+    using PARENT::fireException;
+    using PARENT::lookupNextRow;
+    using PARENT::rowProcessor;
+    using PARENT::dataLinkIncrement;
+
+    IHThorHashJoinArg *hashJoinHelper;
+    IHash *leftHash, *rightHash;
+    ICompare *compareRight, *compareLeftRight;
+
+    unsigned abortLimit, atMost;
+
+    mptag_t lhsDistributeTag, rhsDistributeTag, broadcast2MpTag;
+
+    // Handling failover to a) hashed local lookupjoin b) hash distributed standard join
+    bool localLookupJoin, rhsCollated;
+    bool failoverToLocalLookupJoin, failoverToStdJoin;
+    Owned<IHashDistributor> lhsDistributor, rhsDistributor;
+    ICompare *compareLeft;
+    UnsignedArray flushedRowMarkers;
+
+    atomic_t spiltBroadcastingRHS;
+    CriticalSection broadcastSpillingLock;
+    Owned<IJoinHelper> joinHelper;
+
+    inline bool isSmart() const
+    {
+        switch (container.getKind())
+        {
+            case TAKsmartjoin:
+            case TAKsmartdenormalize:
+            case TAKsmartdenormalizegroup:
+                return true;
+        }
+        return false;
+    }
+    inline bool hasBroadcastSpilt() const { return 0 != atomic_read(&spiltBroadcastingRHS); }
+    inline void setBroadcastingSpilt(bool tf) { atomic_set(&spiltBroadcastingRHS, (int)tf); }
+    rowidx_t clearNonLocalRows(CThorSpillableRowArray &rows, rowidx_t startPos)
+    {
+        rowidx_t clearedRows = 0;
+        rowidx_t numRows = rows.numCommitted();
+        for (rowidx_t r=startPos; r<numRows; r++)
+        {
+            unsigned hv = rightHash->hash(rows.query(r));
+            if ((myNode-1) != (hv % numNodes))
+            {
+                OwnedConstThorRow row = rows.getClear(r); // dispose of
+                ++clearedRows;
+            }
+        }
+        return clearedRows;
+    }
+    // Annoyingly similar to above, used post broadcast when rhsNodeRows collaed into 'rhs'
+    rowidx_t clearNonLocalRows(CThorExpandingRowArray &rows, rowidx_t startPos)
+    {
+        rowidx_t clearedRows = 0;
+        rowidx_t numRows = rows.ordinality();
+        for (rowidx_t r=startPos; r<numRows; r++)
+        {
+            unsigned hv = rightHash->hash(rows.query(r));
+            if ((myNode-1) != (hv % numNodes))
+            {
+                OwnedConstThorRow row = rows.getClear(r); // dispose of
+                ++clearedRows;
+            }
+        }
+        return clearedRows;
+    }
+    bool clearAllNonLocalRows(const char *msg)
+    {
+        // This is likely to free memory, so block others (threads) until done
+        // NB: This will not block appends
+        CriticalBlock b(broadcastSpillingLock);
+        if (hasBroadcastSpilt())
+            return false;
+        setBroadcastingSpilt(true);
+        ActPrintLog("Clearing non-local rows - cause: %s", msg);
+
+        rowidx_t clearedRows = 0;
+        if (rhsCollated)
+        {
+            // This only needs to be done once, no rows will be added after collated
+            clearedRows += clearNonLocalRows(rhs, 0);
+            rhs.compact();
+        }
+        else
+        {
+            /* NB: It is likely that there will be unflushed rows in the rhsNodeRows arrays after we are done here.
+            /* These will need flushing when all is done and clearNonLocalRows will need recalling to process rest
+             */
+            ForEachItemIn(a, rhsNodeRows)
+            {
+                CThorSpillableRowArray &rows = *rhsNodeRows.item(a);
+                /* Record point to which clearNonLocalRows will reach
+                 * so that can resume from that point, when done adding/flushing
+                 */
+                flushedRowMarkers.append(rows.numCommitted());
+                clearedRows += clearNonLocalRows(rows, 0);
+            }
+        }
+        ActPrintLog("handleLowMem: clearedRows = %"RIPF"d", clearedRows);
+        return 0 != clearedRows;
     }
     void setupDistributors()
     {
@@ -1521,10 +1377,32 @@ public:
             left.setown(lhsDistributor->connect(queryRowInterfaces(leftITDL), left.getClear(), leftHash, NULL));
         }
     }
+    void setupHt(rowidx_t size)
+    {
+        if (size < 10)
+            size = 16;
+        else
+        {
+            rowcount_t res = size/3*4; // make HT 1/3 bigger than # rows
+            if ((res < size) || (res > RIMAX)) // check for overflow, or result bigger than rowidx_t size
+                throw MakeActivityException(this, 0, "Too many rows on RHS for hash table: %"RCPF"d", res);
+            size = (rowidx_t)res;
+        }
+        rhsTableLen = size;
+        table.setup(this, size, leftHash, compareLeftRight);
+    }
+    void clearHt()
+    {
+        rhsTableLen = 0;
+        table.reset();
+    }
+
     void getRHS(bool stopping)
     {
+        if (gotRHS)
+            return;
+        gotRHS = true;
 /*
- * This handles LOOKUP and ALL, but most of the complexity is for LOOKUP handling OOM
  * Global LOOKUP:
  * 1) distributes RHS (using broadcaster)
  * 2) sizes the hash table
@@ -1543,83 +1421,76 @@ public:
  * 10) The LHS side is loaded and spilt and sorted if necessary
  * 11) A regular join helper is created to perform a local join against the two hash distributed sorted sides.
  */
-
-        if (gotRHS)
-            return;
-        gotRHS = true;
-        // if input counts known, get global aggregate and pre-allocate HT
-        ThorDataLinkMetaInfo rightMeta;
-        rightITDL->getMetaInfo(rightMeta);
-        if (rightMeta.totalRowsMin == rightMeta.totalRowsMax)
-            rhsTotalCount = rightMeta.totalRowsMax;
+        CMarker marker(*this);
         if (needGlobal)
         {
-            CMessageBuffer msg;
-            msg.append(rhsTotalCount);
-            container.queryJob().queryJobComm().send(msg, 0, mpTag);
-            if (!receiveMsg(msg, 0, mpTag))
-                return;
-            msg.read(rhsTotalCount);
-
-            rowProcessor.start();
-            broadcaster.start(this, mpTag, stopping);
-            broadcastRHS();
-            broadcaster.end();
-            rowProcessor.wait();
-
-            // NB: no more rows can be added to rhsNodeRows at this point, but they could stil be flushed
-
-            rhsRows = 0;
-            ForEachItemIn(a, rhsNodeRows)
+            doBroadcastRHS(stopping);
+            rowidx_t rhsRows;
             {
-                CThorSpillableRowArray &rows = *rhsNodeRows.item(a);
-                rows.flush();
-                rhsRows += rows.numCommitted();
+                CriticalBlock b(broadcastSpillingLock);
+                rhsRows = getGlobalRHSTotal();
             }
+            if (!hasBroadcastSpilt())
+                rhs.ensure(rhsRows);
+
+            // NB: no more rows can be added to rhsNodeRows at this point, but they could still be flushed
 
             if (isSmart() && getOptBool(THOROPT_LKJOIN_LOCALFAILOVER, getOptBool(THOROPT_LKJOIN_HASHJOINFAILOVER))) // For testing purposes only
                 clearAllNonLocalRows("testing");
 
-            if (isLookup())
             {
-                // If spilt, don't size ht table now, if local rhs fits, ht will be sized later
+                /* NB: This does not allocate/will not provoke spilling, but spilling callback still active
+                 * and need to protect rhsNodeRows access
+                 */
+                CriticalBlock b(broadcastSpillingLock);
                 if (!hasBroadcastSpilt())
                 {
-                    rhsTableLen = getHTSize(rhsRows);
-                    // NB: This sizing could cause spilling callback to be triggered
-                    ht.ensure(rhsTableLen); // Pessimistic if LOOKUP,KEEP(1)
-                    /* JCSMORE - failure to size should not be failure condition
-                     * It will mark spiltBroadcastingRHS and try to degrade
-                     * JCS->GH: However, need to catch OOM somehow..
-                     */
-                    ht.clearUnused();
+                    // If spilt, don't size ht table now, if local rhs fits, ht will be sized later
+                    ForEachItemIn(a, rhsNodeRows)
+                    {
+                        CThorSpillableRowArray &rows = *rhsNodeRows.item(a);
+                        rhs.appendRows(rows, true);
+                        rows.kill(); // free up ptr table asap
+                    }
+                    rhsCollated = true;
                 }
             }
-            else
-                rhs.ensure(rhsRows);
+            if (!hasBroadcastSpilt())
+            {
+                rowidx_t uniqueKeys = marker.calculate(rhs, compareRight);
 
-            /* NB: Potentially one of the slaves spilt late after broadcast and rowprocessor finished
-             * Need to remove spill callback and broadcast one last message to know.
-             */
+                // NB: This sizing could cause spilling callback to be triggered
+                setupHt(uniqueKeys);
+                /* JCSMORE - failure to size should not be failure condition
+                 * It will mark spiltBroadcastingRHS and try to degrade
+                 * JCS->GH: However, need to catch OOM somehow..
+                 */
+            }
+            if (failoverToLocalLookupJoin)
+            {
+                /* NB: Potentially one of the slaves spilt late after broadcast and rowprocessor finished
+                 * Need to remove spill callback and broadcast one last message to know.
+                 */
 
-            queryJob().queryRowManager()->removeRowBuffer(this);
+                queryJob().queryRowManager()->removeRowBuffer(this);
 
-            ActPrintLog("Broadcasting final split status");
-            broadcaster.reset();
-            // NB: using a different tag from 1st broadcast, as 2nd on other nodes can start sending before 1st on this has quit receiving
-            broadcaster.start(this, broadcast2MpTag, false);
-            Owned<CSendItem> sendItem = broadcaster.newSendItem(bcast_stop);
-            if (hasBroadcastSpilt())
-                sendItem->setFlag(bcastflag_spilt);
-            broadcaster.send(sendItem); // signals stop to others
-            broadcaster.end();
+                ActPrintLog("Broadcasting final split status");
+                broadcaster.reset();
+                // NB: using a different tag from 1st broadcast, as 2nd on other nodes can start sending before 1st on this has quit receiving
+                broadcaster.start(this, broadcast2MpTag, false);
+                Owned<CSendItem> sendItem = broadcaster.newSendItem(bcast_stop);
+                if (hasBroadcastSpilt())
+                    sendItem->setFlag(bcastflag_spilt);
+                broadcaster.send(sendItem); // signals stop to others
+                broadcaster.end();
+            }
 
             /* All slaves now know whether any one spilt or not, i.e. whether to perform local hash join or not
              * If any have, still need to distribute rest of RHS..
              */
 
             // flush spillable row arrays, and clear any non-locals if spiltBroadcastingRHS and compact
-            if (hasBroadcastSpilt()) // NB: Can only be active for LOOKUP (not ALL)
+            if (hasBroadcastSpilt())
             {
                 ActPrintLog("Spilt whilst broadcasting, will attempt distribute local lookup join");
                 localLookupJoin = true;
@@ -1628,8 +1499,8 @@ public:
                 if (grouped)
                     throw MakeActivityException(this, 0, "Degraded to distributed lookup join, LHS order cannot be preserved");
 
-                // If HT sized already (due to total from meta) and now spilt, too big clear and size later
-                ht.kill();
+                // If HT sized already and now spilt, too big clear and size when local size known
+                clearHt();
 
                 setupDistributors();
 
@@ -1643,14 +1514,7 @@ public:
                     return;
                 }
 
-                ForEachItemIn(a, rhsNodeRows)
-                {
-                    CThorSpillableRowArray &rows = *rhsNodeRows.item(a);
-                    clearNonLocalRows(rows, flushedRowMarkers.item(a));
-                    rows.compact();
-                }
-
-                /* NB: The collected broadcast rows thus far (in rhsNodeRows) were ordered/deterministic.
+                /* NB: The collected broadcast rows thus far (in rhsNodeRows or rhs) were ordered/deterministic.
                  * However, the rest of the rows received via the distributor and non-deterministic.
                  * Therefore the order overall is non-deterministic from this point on.
                  * For that reason, the rest of the RHS (distributed) rows will be processed ahead of the
@@ -1658,12 +1522,24 @@ public:
                  */
                 IArrayOf<IRowStream> streams;
                 streams.append(*right.getLink()); // what remains of 'right' will be read through distributor
-                ForEachItemIn(a2, rhsNodeRows)
+
+                if (rhsCollated)
                 {
-                    CThorSpillableRowArray &sRowArray = *rhsNodeRows.item(a2);
-                    CThorExpandingRowArray rowArray(*this, NULL);
-                    rowArray.transferFrom(sRowArray);
-                    streams.append(*rowArray.createRowStream(0, (rowidx_t)-1, true)); // NB: will kill array when stream exhausted
+                    // NB: If spilt after rhsCollated, callback will have cleared and compacted
+                    streams.append(*rhs.createRowStream()); // NB: will kill array when stream exhausted
+                }
+                else
+                {
+                    // NB: If cleared before rhsCollated, then need to clear non-locals that were added after spill
+                    ForEachItemIn(a, rhsNodeRows)
+                    {
+                        CThorSpillableRowArray &sRowArray = *rhsNodeRows.item(a);
+                        CThorExpandingRowArray rowArray(*this, NULL);
+                        rowArray.transferFrom(sRowArray);
+                        clearNonLocalRows(rowArray, flushedRowMarkers.item(a));
+                        rowArray.compact();
+                        streams.append(*rowArray.createRowStream()); // NB: will kill array when stream exhausted
+                    }
                 }
                 right.setown(createConcatRowStream(streams.ordinality(), streams.getArray()));
             }
@@ -1671,38 +1547,16 @@ public:
             {
                 if (stopping) // broadcast done and no-one spilt, this node can now stop
                     return;
-
-                if (rhsTotalCount != RCUNSET) // verify matches meta if set/calculated (and haven't spilt)
-                    assertex(rhsRows == rhsTotalCount);
             }
         }
         else
         {
             if (stopping) // if local can stop now
                 return;
-            else if (isLookup())
-                localLookupJoin = true;
-            else
-            {
-                if (RCUNSET != rhsTotalCount)
-                {
-                    rhsRows = (rowidx_t)rhsTotalCount;
-                    rhs.ensure(rhsRows);
-                }
-                // local ALL join, must fit into memory
-                while (!abortSoon)
-                {
-                    OwnedConstThorRow row = right->ungroupedNextRow();
-                    if (!row)
-                        break;
-                    rhs.append(row.getClear());
-                }
-                if (RIUNSET == rhsRows)
-                    rhsRows = rhs.ordinality();
-            }
+            localLookupJoin = true;
         }
 
-        if (localLookupJoin) // NB: Can only be active for LOOKUP (not ALL)
+        if (localLookupJoin) // NB: Can only be active for LOOKUP
         {
             Owned<IThorRowLoader> rowLoader;
             if (failoverToStdJoin)
@@ -1720,8 +1574,8 @@ public:
                 // i.e. will fire OOM if runs out of memory loading local right
                 rowLoader.setown(createThorRowLoader(*this, queryRowInterfaces(rightITDL), compareRight, false, rc_allMem, SPILL_PRIORITY_DISABLE));
             }
-            Owned<IRowStream> rightStream = rowLoader->load(right, abortSoon, false, &rhs);
 
+            Owned<IRowStream> rightStream = rowLoader->load(right, abortSoon, false, &rhs);
             if (!rightStream)
             {
                 ActPrintLog("RHS local rows fitted in memory, count: %"RIPF"d", rhs.ordinality());
@@ -1737,24 +1591,21 @@ public:
                 rowLoader.clear();
                 Owned<IThorRowCollector> collector = createThorRowCollector(*this, queryRowInterfaces(rightITDL), compareRight,false, rc_mixed, SPILL_PRIORITY_LOOKUPJOIN);
                 collector->setOptions(rcflag_noAllInMemSort); // If fits into memory, don't want it sorted
-                rhsRows = rhs.ordinality();
-                collector->transferRowsIn(rhs);
-                rhsTableLen = getHTSize(rhsRows);
+
+                rowidx_t uniqueKeys = marker.calculate(rhs, compareRight);
+
+                collector->transferRowsIn(rhs); // can spill after this
 
                 // could cause spilling of 'rhs'
-                ht.ensure(rhsTableLen); // Pessimistic if LOOKUP,KEEP(1)
+                setupHt(uniqueKeys);
                 /* JCSMORE - failure to size should not be failure condition
                  * If it failed, the 'collector' will have spilt and it will not need HT
                  * JCS->GH: However, need to catch OOM somehow..
                  */
-
-                ht.clearUnused();
                 rightStream.setown(collector->getStream(false, &rhs));
             }
             if (rightStream) // NB: returned stream, implies spilt AND sorted, if not, 'rhs' is filled
             {
-                ht.kill(); // no longer needed
-
                 ActPrintLog("RHS spilt to disk. Standard Join will be used");
 
                 // NB: lhs ordering and grouping lost from here on.. (will have been caught earlier if global)
@@ -1792,60 +1643,195 @@ public:
             }
             else
                 ActPrintLog("Local RHS loaded to memory, performing local lookup join");
+            // If got this far, without turning into a standard fully distributed join, then all rows are in rhs
         }
-        if (!stopping)
-            prepareRHS();
-    }
-    void prepareRHS()
-    {
-        // NB: this method is not used if we've failed over to a regular join in getRHS()
 
         // JCSMORE - would be nice to make this multi-core, clashes and compares can be expensive
-        if (localLookupJoin)
+
+        addRowsToHT(rhs, marker);
+        ActPrintLog("rhs table: %d elements", rhsTableLen);
+    }
+public:
+    using PARENT::queryJob;
+
+    CLookupJoinActivityBase(CGraphElementBase *_container) : PARENT(_container)
+    {
+        hashJoinHelper = (IHThorHashJoinArg *)queryHelper();
+
+        atMost = 0;
+        localLookupJoin = rhsCollated = false;
+        broadcast2MpTag = lhsDistributeTag = rhsDistributeTag = TAG_NULL;
+        setBroadcastingSpilt(false);
+
+        grouped = hashJoinHelper->queryOutputMeta()->isGrouped();
+        flags = hashJoinHelper->getJoinFlags();
+        leftHash = hashJoinHelper->queryHashLeft();
+        rightHash = hashJoinHelper->queryHashRight();
+        compareRight = hashJoinHelper->queryCompareRight();
+        compareLeft = hashJoinHelper->queryCompareLeft();
+        compareLeftRight = hashJoinHelper->queryCompareLeftRight();
+        if (JFmanylookup & flags)
+            returnMany = true;
+        keepLimit = hashJoinHelper->getKeepLimit();
+        abortLimit = hashJoinHelper->getMatchAbortLimit();
+        atMost = hashJoinHelper->getJoinLimit();
+
+        fuzzyMatch = 0 != (JFmatchrequired & flags);
+        bool maySkip = 0 != (flags & JFtransformMaySkip);
+        dedup = false;
+        if (!maySkip && !fuzzyMatch)
         {
-            // If got this far, without turning into a standard fully distributed join, then all rows are in rhs
-            if (isLookup()) // if isAll(), want to leave them in rhs as is.
+            if (returnMany)
             {
-                rowidx_t r=0;
-                for (; r<rhs.ordinality(); r++)
-                    addRowHt(rhs.getClear(r));
-                rhs.kill(); // free up ptr table asap
-            }
-        }
-        else if (needGlobal)
-        {
-            // If global and !localLookupJoin, then rows are in 'rhsNodeRows' arrays
-            if (isAll())
-            {
-                ForEachItemIn(a2, rhsNodeRows)
+                if ((1==keepLimit) && (0==atMost) && (0==abortLimit))
                 {
-                    CThorSpillableRowArray &rows = *rhsNodeRows.item(a2);
-                    rowidx_t r=0;
-                    for (; r<rows.numCommitted(); r++)
-                        rhs.append(rows.getClear(r));
-                    rows.kill(); // free up ptr table asap
+                    dedup = true;
+                    returnMany = false; // JCS->GH - Any exceptions?
                 }
             }
             else
-            {
-                ForEachItemIn(a2, rhsNodeRows)
-                {
-                    CThorSpillableRowArray &rows = *rhsNodeRows.item(a2);
-                    rowidx_t r=0;
-                    for (; r<rows.numCommitted(); r++)
-                        addRowHt(rows.getClear(r));
-                    rows.kill(); // free up ptr table asap
-                }
-            }
+                dedup = true;
         }
-        ActPrintLog("rhs table: %d elements", rhsRows);
-        if (isLookup())
-            rhsTable = ht.getRowArray();
-        else
+        if (0 == abortLimit)
+            abortLimit = (unsigned)-1;
+        if (0 == atMost)
+            atMost = (unsigned)-1;
+        if (abortLimit < atMost)
+            atMost = abortLimit;
+
+        failoverToLocalLookupJoin = failoverToStdJoin = isSmart();
+        ActPrintLog("failoverToLocalLookupJoin=%s, failoverToStdJoin=%s",
+                failoverToLocalLookupJoin?"true":"false", failoverToStdJoin?"true":"false");
+    }
+    inline const void *getRHSRow(rowidx_t i)
+    {
+        return rhs.query(i);
+    }
+    bool exceedsLimit(rowidx_t count, const void *left, const void *right, const void *&failRow)
+    {
+        if ((unsigned)-1 != atMost)
         {
-            assertex(isAll());
-            rhsTable = rhs.getRowArray();
+            failRow = NULL;
+            if (count>abortLimit)
+            {
+                if (0 == (JFmatchAbortLimitSkips & flags))
+                {
+                    Owned<IException> e;
+                    try
+                    {
+                        if (hashJoinHelper)
+                            hashJoinHelper->onMatchAbortLimitExceeded();
+                        CommonXmlWriter xmlwrite(0);
+                        if (outputMeta && outputMeta->hasXML())
+                            outputMeta->toXML((const byte *) leftRow.get(), xmlwrite);
+                        throw MakeActivityException(this, 0, "More than %d match candidates in join for row %s", abortLimit, xmlwrite.str());
+                    }
+                    catch (IException *_e)
+                    {
+                        if (0 == (JFonfail & flags))
+                            throw;
+                        e.setown(_e);
+                    }
+                    RtlDynamicRowBuilder ret(allocator);
+                    size32_t transformedSize = hashJoinHelper->onFailTransform(ret, leftRow, defaultRight, e.get());
+                    if (transformedSize)
+                        failRow = ret.finalizeRowClear(transformedSize);
+                }
+                else
+                    leftMatch = true; // there was a lhs match, even though rhs group exceeded limit. Therefore this lhs will not be considered left only/left outer
+                return true;
+            }
+            else if (count>atMost)
+                return true;
         }
+        return false;
+    }
+// IThorSlaveActivity overloaded methods
+    virtual void init(MemoryBuffer &data, MemoryBuffer &slaveData)
+    {
+        PARENT::init(data, slaveData);
+
+        if (!container.queryLocal())
+        {
+            broadcast2MpTag = container.queryJob().deserializeMPTag(data);
+            lhsDistributeTag = container.queryJob().deserializeMPTag(data);
+            rhsDistributeTag = container.queryJob().deserializeMPTag(data);
+        }
+    }
+    virtual void start()
+    {
+        ActivityTimer s(totalCycles, timeActivities, NULL);
+
+        PARENT::start();
+
+        setBroadcastingSpilt(false);
+        localLookupJoin = rhsCollated = false;
+        flushedRowMarkers.kill();
+
+        if (failoverToLocalLookupJoin)
+        {
+            if (needGlobal)
+                queryJob().queryRowManager()->addRowBuffer(this);
+        }
+        if ((flags & JFonfail) || (flags & JFleftouter))
+        {
+            RtlDynamicRowBuilder rr(rightAllocator);
+            rr.ensureRow();
+            size32_t rrsz = hashJoinHelper->createDefaultRight(rr);
+            defaultRight.setown(rr.finalizeRowClear(rrsz));
+        }
+        if (!isSmart())
+        {
+            bool inputGrouped = leftITDL->isGrouped();
+            dbgassertex(inputGrouped == grouped); // std. lookup join expects these to match
+        }
+    }
+    CATCH_NEXTROW()
+    {
+        ActivityTimer t(totalCycles, timeActivities, NULL);
+        if (!gotRHS)
+            getRHS(false);
+        OwnedConstThorRow row;
+        if (joinHelper) // regular join (hash join)
+            row.setown(joinHelper->nextRow());
+        else
+            row.setown(lookupNextRow());
+        if (!row.get())
+            return NULL;
+        dataLinkIncrement();
+        return row.getClear();
+    }
+    virtual void abort()
+    {
+        PARENT::abort();
+        if (rhsDistributor)
+            rhsDistributor->abort();
+        if (lhsDistributor)
+            lhsDistributor->abort();
+    }
+    virtual void stop()
+    {
+        if (!gotRHS && needGlobal)
+            getRHS(true); // If global, need to handle RHS until all are slaves stop
+
+        // JCS->GH - if in a child query, it would be good to preserve RHS.. would need tip/flag from codegen that constant
+        clearHt();
+        if (rhsDistributor)
+        {
+            rhsDistributor->disconnect(true);
+            rhsDistributor->join();
+        }
+        if (lhsDistributor)
+        {
+            lhsDistributor->disconnect(true);
+            lhsDistributor->join();
+        }
+        joinHelper.clear();
+        PARENT::stop();
+    }
+    virtual bool isGrouped()
+    {
+        return isSmart() ? false : inputs.item(0)->isGrouped();
     }
 // IBCastReceive
     virtual void bCastReceive(CSendItem *sendItem)
@@ -1870,9 +1856,464 @@ public:
         // NB: only installed if lookup join and global
         return clearAllNonLocalRows("Out of memory callback");
     }
+    virtual bool addLocalRHSRow(CThorSpillableRowArray &localRhsRows, const void *row)
+    {
+        if (hasBroadcastSpilt())
+        {
+            // keep it only if it hashes to my node
+            unsigned hv = rightHash->hash(row);
+            if ((myNode-1) == (hv % numNodes))
+                PARENT::addLocalRHSRow(localRhsRows, row);
+            // ok so switch tactics.
+            // clearAllNonLocalRows() will have cleared out non-locals by now
+            // Returning false here, will stop the broadcaster
+
+            return false;
+        }
+        else
+        {
+            /* NB: It could still spill here, i.e. before appending a non-local row
+             * When all is done, a last pass is needed to clear out non-locals
+             */
+            PARENT::addLocalRHSRow(localRhsRows, row);
+        }
+        return true;
+    }
+    virtual void addRowsToHT(CThorExpandingRowArray &rows, CMarker &marker) = 0;
 };
+
+
+class CHTBase
+{
+protected:
+    OwnedConstThorRow htMemory;
+    IHash *leftHash;
+    ICompare *compareLeftRight;
+    rowidx_t htSize;
+public:
+    CHTBase()
+    {
+        reset();
+    }
+    void setup(rowidx_t size, IHash *_leftHash, ICompare *_compareLeftRight)
+    {
+        htSize = size;
+        leftHash = _leftHash;
+        compareLeftRight = _compareLeftRight;
+    }
+    void reset()
+    {
+        htMemory.clear();
+        htSize = 0;
+        leftHash = NULL;
+        compareLeftRight = NULL;
+    }
+};
+
+class CLookupHT : public CHTBase
+{
+    CLookupJoinActivityBase<CLookupHT> *activity;
+    const void **ht;
+
+    const void *findFirst(const void *left)
+    {
+        unsigned h = leftHash->hash(left)%htSize;
+        loop
+        {
+            const void *right = ht[h];
+            if (!right)
+                break;
+            if (0 == compareLeftRight->docompare(left, right))
+                return right;
+            h++;
+            if (h>=htSize)
+                h = 0;
+        }
+        return NULL;
+    }
+public:
+    CLookupHT()
+    {
+        reset();
+    }
+    void setup(CLookupJoinActivityBase<CLookupHT> *_activity, rowidx_t size, IHash *leftHash, ICompare *compareLeftRight)
+    {
+        CHTBase::setup(size, leftHash, compareLeftRight);
+        activity = _activity;
+        size32_t sz = sizeof(const void *)*size;
+        htMemory.setown(activity->queryJob().queryRowManager()->allocate(sz, activity->queryContainer().queryId()));
+        ht = (const void **)htMemory.get();
+        memset(ht, 0, sz);
+    }
+    void reset()
+    {
+        CHTBase::reset();
+        ht = NULL;
+    }
+    inline void addEntry(const void *row, unsigned hash)
+    {
+        loop
+        {
+            const void *&htRow = ht[hash];
+            if (!htRow)
+            {
+                htRow = row;
+                break;
+            }
+            hash++;
+            if (hash>=htSize)
+                hash = 0;
+        }
+    }
+    inline const void *getNextRHS()
+    {
+        return NULL; // no next in LOOKUP without MANY
+    }
+    inline const void *getFirstRHSMatch(const void *leftRow, const void *&failRow)
+    {
+        failRow = NULL;
+        return findFirst(leftRow);
+    }
+};
+
+struct HtEntry { rowidx_t index, count; };
+class CLookupManyHT : public CHTBase
+{
+    CLookupJoinActivityBase<CLookupManyHT> *activity;
+    HtEntry *ht;
+    HtEntry currentHashEntry;
+
+    inline HtEntry *lookup(unsigned hash)
+    {
+        HtEntry *e = ht+hash;
+        if (0 == e->count)
+            return NULL;
+        return e;
+    }
+    const void *findFirst(const void *left)
+    {
+        unsigned h = leftHash->hash(left)%htSize;
+        loop
+        {
+            HtEntry *e = lookup(h);
+            if (!e)
+                break;
+            const void *right = activity->getRHSRow(e->index);
+            if (0 == compareLeftRight->docompare(left, right))
+            {
+                currentHashEntry = *e;
+                return right;
+            }
+            h++;
+            if (h>=htSize)
+                h = 0;
+        }
+        return NULL;
+    }
+public:
+    CLookupManyHT()
+    {
+        reset();
+    }
+    void setup(CLookupJoinActivityBase<CLookupManyHT> *_activity, rowidx_t size, IHash *leftHash, ICompare *compareLeftRight)
+    {
+        activity = _activity;
+        CHTBase::setup(size, leftHash, compareLeftRight);
+        size32_t sz = sizeof(HtEntry)*size;
+        htMemory.setown(activity->queryJob().queryRowManager()->allocate(sz, activity->queryContainer().queryId()));
+        ht = (HtEntry *)htMemory.get();
+        memset(ht, 0, sz);
+    }
+    inline void addEntry(const void *row, unsigned hash, rowidx_t index, rowidx_t count)
+    {
+        loop
+        {
+            HtEntry &e = ht[hash];
+            if (!e.count)
+            {
+                e.index = index;
+                e.count = count;
+                break;
+            }
+            hash++;
+            if (hash>=htSize)
+                hash = 0;
+        }
+    }
+    void reset()
+    {
+        CHTBase::reset();
+        ht = NULL;
+    }
+    inline const void *getNextRHS()
+    {
+        if (1 == currentHashEntry.count)
+            return NULL;
+        --currentHashEntry.count;
+        return activity->getRHSRow(++currentHashEntry.index);
+    }
+    inline const void *getFirstRHSMatch(const void *leftRow, const void *&failRow)
+    {
+        const void *right = findFirst(leftRow);
+        if (right)
+        {
+            if (activity->exceedsLimit(currentHashEntry.count, leftRow, right, failRow))
+                return NULL;
+        }
+        return right;
+    }
+};
+
+class CLookupJoinSlaveActivity : public CLookupJoinActivityBase<CLookupHT>
+{
+public:
+    CLookupJoinSlaveActivity(CGraphElementBase *_container) : CLookupJoinActivityBase<CLookupHT>(_container)
+    {
+    }
+    virtual void addRowsToHT(CThorExpandingRowArray &rows, CMarker &marker)
+    {
+        rowidx_t pos=0;
+        rowidx_t pos2;
+        loop
+        {
+            pos2 = marker.findNextBoundary();
+            if (0 == pos2)
+                break;
+            const void *row = rhs.query(pos);
+            unsigned h = rightHash->hash(row)%rhsTableLen;
+            table.addEntry(row, h);
+            pos = pos2+1;
+        }
+        // Rows now in hash table, rhs arrays no longe needed
+        clearRHS();
+    }
+};
+
+class CLookupManyJoinSlaveActivity : public CLookupJoinActivityBase<CLookupManyHT>
+{
+public:
+    CLookupManyJoinSlaveActivity(CGraphElementBase *_container) : CLookupJoinActivityBase<CLookupManyHT>(_container)
+    {
+    }
+    virtual void addRowsToHT(CThorExpandingRowArray &rows, CMarker &marker)
+    {
+        rowidx_t pos=0;
+        rowidx_t pos2;
+        loop
+        {
+            pos2 = marker.findNextBoundary();
+            if (0 == pos2)
+                break;
+            rowidx_t count = pos2-pos;
+            /* JCS->GH - Could you/do you spot LOOKUP MANY, followed by DEDUP(key) ?
+             * It feels like we should only dedup if code gen spots, rather than have LOOKUP without MANY option
+             * i.e. feels like LOOKUP without MANY should be deprecated..
+            */
+            const void *row = rhs.query(pos);
+            unsigned h = rightHash->hash(row)%rhsTableLen;
+            // NB: 'pos' and 'count' won't be used if dedup variety
+            table.addEntry(row, h, pos, count);
+            pos = pos2;
+        }
+    }
+};
+
+class CAllTable
+{
+    const void **rows;
+    rowidx_t htSize;
+    rowidx_t nextRhsRow;
+
+public:
+    CAllTable()
+    {
+        reset();
+    }
+    void setup(rowidx_t size, const void **_rows)
+    {
+        htSize = size;
+        rows = _rows;
+        nextRhsRow = 0;
+    }
+    void reset()
+    {
+        htSize = 0;
+        rows = NULL;
+        nextRhsRow = 0;
+    }
+    inline const void *getNextRHS()
+    {
+        if (++nextRhsRow<htSize)
+            return rows[nextRhsRow];
+        return NULL;
+    }
+    inline const void *getFirstRHSMatch(const void *leftRow, const void *&failRow)
+    {
+        nextRhsRow = 0;
+        failRow = NULL;
+        return rows[0]; // guaranteed to be at least one row
+    }
+};
+
+class CAllJoinSlaveActivity : public CInMemJoinBase<CAllTable, IHThorAllJoinArg>
+{
+    typedef CInMemJoinBase<CAllTable, IHThorAllJoinArg> PARENT;
+
+    CAllOrLookupHelper<IHThorAllJoinArg> helper;
+    IHThorAllJoinArg *allJoinHelper;
+
+protected:
+    void getRHS(bool stopping)
+    {
+        if (gotRHS)
+            return;
+        gotRHS = true;
+
+        // if input counts known, get global aggregate and pre-allocate RHS size
+        ThorDataLinkMetaInfo rightMeta;
+        rightITDL->getMetaInfo(rightMeta);
+        rowcount_t rhsTotalCount;
+        if (rightMeta.totalRowsMin == rightMeta.totalRowsMax)
+            rhsTotalCount = rightMeta.totalRowsMax;
+        else
+            rhsTotalCount = RCUNSET;
+        // ALL join must fit into memory
+        if (needGlobal)
+        {
+            CMessageBuffer msg;
+            msg.append(rhsTotalCount);
+            container.queryJob().queryJobComm().send(msg, 0, mpTag);
+            if (!receiveMsg(msg, 0, mpTag))
+                return;
+            msg.read(rhsTotalCount);
+            if (RCUNSET != rhsTotalCount)
+            {
+                if (rhsTotalCount > RIMAX)
+                    throw MakeActivityException(this, 0, "Too many rows on RHS for ALL join: %"RCPF"d", rhsTotalCount);
+                rhsTableLen = (rowidx_t)rhsTotalCount;
+                rhs.ensure(rhsTableLen);
+            }
+            doBroadcastRHS(stopping);
+            if (stopping) // broadcast done and no-one spilt, this node can now stop
+                return;
+
+            rowidx_t rhsRows = getGlobalRHSTotal();
+            if (rhsTotalCount != RCUNSET)
+                assertex(rhsRows == rhsTotalCount);
+            else
+            {
+                rhsTableLen = (rowidx_t)rhsRows;
+                rhs.ensure(rhsTableLen);
+            }
+            ForEachItemIn(a2, rhsNodeRows)
+            {
+                CThorSpillableRowArray &rows = *rhsNodeRows.item(a2);
+                rowidx_t r=0;
+                for (; r<rows.numCommitted(); r++)
+                    rhs.append(rows.getClear(r));
+                rows.kill(); // free up ptr table asap
+            }
+        }
+        else
+        {
+            if (stopping) // if local can stop now
+                return;
+            if (RCUNSET != rhsTotalCount)
+            {
+                if (rhsTotalCount > RIMAX)
+                    throw MakeActivityException(this, 0, "Too many rows on RHS for ALL join: %"RCPF"d", rhsTotalCount);
+                rhsTableLen = (rowidx_t)rhsTotalCount;
+                rhs.ensure(rhsTableLen);
+            }
+            while (!abortSoon)
+            {
+                OwnedConstThorRow row = right->ungroupedNextRow();
+                if (!row)
+                    break;
+                rhs.append(row.getClear());
+            }
+            rhsTableLen = rhs.ordinality();
+            if (rhsTotalCount != RCUNSET) // verify matches meta if set/calculated
+                assertex(rhsTableLen == rhsTotalCount);
+        }
+        ActPrintLog("rhs table: %d elements", rhsTableLen);
+        table.setup(rhsTableLen, rhs.getRowArray());
+    }
+public:
+    CAllJoinSlaveActivity(CGraphElementBase *_container) : PARENT(_container)
+    {
+        helper.setHelper((IHThorAllJoinArg *)queryHelper());
+        allJoinHelper = (IHThorAllJoinArg *)queryHelper();
+        flags = allJoinHelper->getJoinFlags();
+        returnMany = true;
+        keepLimit = allJoinHelper->getKeepLimit();
+        fuzzyMatch = 0 != (JFmatchrequired & flags);
+        grouped = allJoinHelper->queryOutputMeta()->isGrouped();
+    }
+// IThorSlaveActivity overloaded methods
+    virtual void start()
+    {
+        ActivityTimer s(totalCycles, timeActivities, NULL);
+
+        PARENT::start();
+
+        if ((flags & JFonfail) || (flags & JFleftouter))
+        {
+            RtlDynamicRowBuilder rr(rightAllocator);
+            rr.ensureRow();
+            size32_t rrsz = allJoinHelper->createDefaultRight(rr);
+            defaultRight.setown(rr.finalizeRowClear(rrsz));
+        }
+    }
+    CATCH_NEXTROW()
+    {
+        ActivityTimer t(totalCycles, timeActivities, NULL);
+        if (!gotRHS)
+            getRHS(false);
+        OwnedConstThorRow row = lookupNextRow();
+        if (!row.get())
+            return NULL;
+        dataLinkIncrement();
+        return row.getClear();
+    }
+    virtual void stop()
+    {
+        if (!gotRHS && needGlobal)
+            getRHS(true); // If global, need to handle RHS until all are slaves stop
+        PARENT::stop();
+    }
+    virtual bool isGrouped() { return inputs.item(0)->isGrouped(); }
+// IBCastReceive
+    virtual void bCastReceive(CSendItem *sendItem)
+    {
+        rowProcessor.addBlock(sendItem); // NB: NULL indicates end
+    }
+};
+
 
 CActivityBase *createLookupJoinSlave(CGraphElementBase *container) 
 { 
-    return new CLookupJoinActivity(container);
+    IHThorHashJoinArg *hashJoinHelper = (IHThorHashJoinArg *)container->queryHelper();
+    unsigned flags = hashJoinHelper->getJoinFlags();
+    if (JFmanylookup & flags)
+    {
+        bool dedup = false;
+        if (0 == (flags & (JFtransformMaySkip|JFmatchrequired)))
+        {
+            unsigned keepLimit = hashJoinHelper->getKeepLimit();
+            unsigned abortLimit = hashJoinHelper->getMatchAbortLimit();
+            unsigned atMost = hashJoinHelper->getJoinLimit();
+            dedup = (1==keepLimit) && (0==atMost) && (0==abortLimit);
+        }
+        if (dedup)
+            return new CLookupJoinSlaveActivity(container);
+    }
+    return new CLookupManyJoinSlaveActivity(container);
 }
+
+CActivityBase *createAllJoinSlave(CGraphElementBase *container)
+{
+    return new CAllJoinSlaveActivity(container);
+}
+
+

--- a/thorlcr/slave/slave.cpp
+++ b/thorlcr/slave/slave.cpp
@@ -232,6 +232,7 @@ void ProcessSlaveActivity::done()
 #include "xmlwrite/thxmlwriteslave.ipp"
 
 CActivityBase *createLookupJoinSlave(CGraphElementBase *container);
+CActivityBase *createAllJoinSlave(CGraphElementBase *container);
 CActivityBase *createXmlParseSlave(CGraphElementBase *container);
 CActivityBase *createKeyDiffSlave(CGraphElementBase *container);
 CActivityBase *createKeyPatchSlave(CGraphElementBase *container);
@@ -440,13 +441,15 @@ public:
             case TAKlookupjoin:
             case TAKlookupdenormalize:
             case TAKlookupdenormalizegroup:
-            case TAKalljoin:
-            case TAKalldenormalize:
-            case TAKalldenormalizegroup:
             case TAKsmartjoin:
             case TAKsmartdenormalize:
             case TAKsmartdenormalizegroup:
                 ret = createLookupJoinSlave(this);
+                break;
+            case TAKalljoin:
+            case TAKalldenormalize:
+            case TAKalldenormalizegroup:
+                ret = createAllJoinSlave(this);
                 break;
             case TAKselfjoin:
                 if (queryLocalOrGrouped())

--- a/thorlcr/thorutil/thmem.hpp
+++ b/thorlcr/thorutil/thmem.hpp
@@ -349,6 +349,7 @@ public:
     void transferFrom(CThorSpillableRowArray &src);
     void removeRows(rowidx_t start, rowidx_t n);
     bool appendRows(CThorExpandingRowArray &inRows, bool takeOwnership);
+    bool appendRows(CThorSpillableRowArray &inRows, bool takeOwnership);
     void clearUnused();
     void sort(ICompare &compare, unsigned maxCores);
     void reorder(rowidx_t start, rowidx_t num, rowidx_t *neworder);
@@ -481,6 +482,7 @@ public:
     void deserialize(size32_t sz, const void *buf, bool hasNulls){ CThorExpandingRowArray::deserialize(sz, buf); }
     void deserializeRow(IRowDeserializerSource &in) { CThorExpandingRowArray::deserializeRow(in); }
     bool ensure(rowidx_t requiredRows) { return CThorExpandingRowArray::ensure(requiredRows); }
+    void transferRowsCopy(const void **outRows, bool takeOwnership);
 
     virtual IThorArrayLock &queryLock() { return *this; }
 // IThorArrayLock


### PR DESCRIPTION
LOOKUP MANY was horrendously slow if there were truly many
duplicates. New scheme avoids pathogenic case and also improves
efficiency of ATMOST processing.

Refactored All vs LOOKUP vs LOOKUP MANY implementations

Signed-off-by: Jake Smith <jake.smith@lexisnexis.com>